### PR TITLE
Generate Windows bat for sh files

### DIFF
--- a/run_all_tests.bat
+++ b/run_all_tests.bat
@@ -1,0 +1,39 @@
+@echo off
+REM Simple test runner script
+
+REM Get the directory where this script is located
+set SCRIPT_DIR=%~dp0
+
+echo Running C to PlantUML Converter Tests
+echo ========================================
+echo Script directory: %SCRIPT_DIR%
+
+REM Change to the script directory
+cd /d %SCRIPT_DIR%
+
+REM Detect Python version
+where python >nul 2>nul
+if %errorlevel%==0 (
+    set PYTHON_CMD=python
+) else (
+    echo Error: Python not found. Please install Python 3.8+
+    exit /b 1
+)
+
+echo Using Python:
+%PYTHON_CMD% --version
+echo Working directory: %cd%
+
+REM Run the test suite
+%PYTHON_CMD% run_all_tests.py
+
+REM Check exit code and provide feedback
+if %errorlevel%==0 (
+    echo.
+    echo All tests passed successfully!
+    exit /b 0
+) else (
+    echo.
+    echo Some tests failed. Please check the output above.
+    exit /b 1
+)

--- a/run_example.bat
+++ b/run_example.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Run the example workflow using the provided config.json and source files
+
+set SCRIPT_DIR=%~dp0
+cd /d %SCRIPT_DIR%
+
+REM Clean previous output
+echo Cleaning previous output...
+if exist plantuml_output rmdir /s /q plantuml_output
+mkdir plantuml_output
+
+REM Run the workflow
+echo Running example workflow with config.json...
+python main.py workflow example/source example/config.json
+
+REM Output location
+echo PlantUML diagrams generated in: %SCRIPT_DIR%plantuml_output


### PR DESCRIPTION
Generate Windows `.bat` files for `run_all_tests.sh` and `run_example.sh` to enable direct execution on Windows.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-0147df6e-a0ef-4c1a-a72c-7c610aced4ec) · [Cursor](https://cursor.com/background-agent?bcId=bc-0147df6e-a0ef-4c1a-a72c-7c610aced4ec)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)