### PR TITLE
Run example, commit output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ cli_output/
 test_plantuml_output/
 *.puml
 
+# Allow output directory to be tracked
+!output/
+!output/*.puml
+!output/*.json
+
 # Python cache and compiled files
 __pycache__/
 *.py[cod]
@@ -57,6 +62,7 @@ Thumbs.db
 !simple_config.json
 !test_model.json
 !example/config.json
+!output/*.json
 test_*.json
 final_*.json
 cleanup_*.json

--- a/output/geometry.puml
+++ b/output/geometry.puml
@@ -1,0 +1,31 @@
+@startuml geometry
+
+class "geometry" as GEOMETRY <<source>> #LightBlue
+{
+    -- Global Variables --
+    triangle_t tri
+    return tri
+    int x1
+    int y1
+    int x2
+    int y2
+    int x3
+    int y3
+    return area
+    -- Functions --
+    triangle_t create_triangle()
+    int triangle_area()
+}
+
+class "geometry" as HEADER_GEOMETRY <<header>> #LightGreen
+{
+    -- Macros --
+    + #define GEOMETRY_H
+    -- Functions --
+    + triangle_t create_triangle()
+    + int triangle_area()
+}
+
+GEOMETRY --> HEADER_GEOMETRY : <<include>>
+
+@enduml

--- a/output/logger.puml
+++ b/output/logger.puml
@@ -1,0 +1,29 @@
+@startuml logger
+
+class "logger" as LOGGER <<source>> #LightBlue
+{
+    -- Typedefs --
+    + typedef void (*)(...) log_callback_t
+    -- Global Variables --
+    log_callback_t current_cb
+    va_list args
+    const char * level_str
+    -- Functions --
+    void set_log_callback()
+    void log_message()
+}
+
+class "logger" as HEADER_LOGGER <<header>> #LightGreen
+{
+    -- Macros --
+    + #define LOGGER_H
+    -- Typedefs --
+    + typedef void (*)(...) log_callback_t
+    -- Functions --
+    + void set_log_callback()
+    + void log_message()
+}
+
+LOGGER --> HEADER_LOGGER : <<include>>
+
+@enduml

--- a/output/math_utils.puml
+++ b/output/math_utils.puml
@@ -1,0 +1,34 @@
+@startuml math_utils
+
+class "math_utils" as MATH_UTILS <<source>> #LightBlue
+{
+    -- Typedefs --
+    + typedef double real_t
+    + typedef int (*)(...) math_op_t
+    -- Global Variables --
+    return a + b
+    return a - b
+    int sum
+    size_t i
+    -- Functions --
+    int add()
+    int subtract()
+    real_t average()
+}
+
+class "math_utils" as HEADER_MATH_UTILS <<header>> #LightGreen
+{
+    -- Macros --
+    + #define MATH_UTILS_H
+    -- Typedefs --
+    + typedef double real_t
+    + typedef int (*)(...) math_op_t
+    -- Functions --
+    + int add()
+    + int subtract()
+    + real_t average()
+}
+
+MATH_UTILS --> HEADER_MATH_UTILS : <<include>>
+
+@enduml

--- a/output/model.json
+++ b/output/model.json
@@ -1,0 +1,1335 @@
+{
+  "project_name": "source",
+  "project_root": "/workspace/example/source",
+  "files": {
+    "complex_example.h": {
+      "file_path": "/workspace/example/source/complex_example.h",
+      "relative_path": "complex_example.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {
+        "NestedInfo_tag": {
+          "name": "NestedInfo_tag",
+          "fields": [
+            {
+              "name": "id",
+              "type": "id_t",
+              "array_size": null
+            },
+            {
+              "name": "description",
+              "type": "char[MAX_LABEL_LEN]",
+              "array_size": null
+            },
+            {
+              "name": "log_level",
+              "type": "log_level_t",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        },
+        "ComplexExample_tag": {
+          "name": "ComplexExample_tag",
+          "fields": [
+            {
+              "name": "info",
+              "type": "NestedInfo_t",
+              "array_size": null
+            },
+            {
+              "name": "status",
+              "type": "CE_Status_t",
+              "array_size": null
+            },
+            {
+              "name": "values",
+              "type": "int[5]",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        }
+      },
+      "enums": {
+        "CE_Status_tag": {
+          "name": "CE_Status_tag",
+          "values": [
+            "CE_STATUS_OK",
+            "CE_STATUS_WARN",
+            "CE_STATUS_FAIL"
+          ]
+        }
+      },
+      "functions": [],
+      "globals": [
+        {
+          "name": "id",
+          "type": "id_t",
+          "array_size": null
+        },
+        {
+          "name": "log_level",
+          "type": "log_level_t",
+          "array_size": null
+        },
+        {
+          "name": "info",
+          "type": "NestedInfo_t",
+          "array_size": null
+        },
+        {
+          "name": "status",
+          "type": "CE_Status_t",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "config.h",
+        "logger.h"
+      ],
+      "macros": [
+        "COMPLEX_EXAMPLE_H"
+      ],
+      "typedefs": {
+        "id": "struct NestedInfo_tag { id_t",
+        "CE_Status_t": "enum CE_Status_tag { CE_STATUS_OK = 0, CE_STATUS_WARN, CE_STATUS_FAIL }",
+        "info": "struct ComplexExample_tag { NestedInfo_t"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "id",
+          "original_type": "struct NestedInfo_tag { id_t",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "CE_Status_t",
+          "original_type": "enum CE_Status_tag { CE_STATUS_OK = 0, CE_STATUS_WARN, CE_STATUS_FAIL }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "info",
+          "original_type": "struct ComplexExample_tag { NestedInfo_t",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    },
+    "config.h": {
+      "file_path": "/workspace/example/source/config.h",
+      "relative_path": "config.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {
+        "GlobalStatus": {
+          "name": "GlobalStatus",
+          "values": [
+            "GS_OK",
+            "GS_ERROR",
+            "GS_UNKNOWN"
+          ]
+        }
+      },
+      "functions": [],
+      "globals": [],
+      "includes": [
+        "stddef.h",
+        "stdint.h"
+      ],
+      "macros": [
+        "CONFIG_H",
+        "PROJECT_NAME",
+        "MAX_LABEL_LEN",
+        "DEFAULT_BUFFER_SIZE"
+      ],
+      "typedefs": {
+        "id_t": "uint32_t",
+        "status_t": "int32_t",
+        "GlobalStatus_t": "enum GlobalStatus"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "id_t",
+          "original_type": "uint32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "status_t",
+          "original_type": "int32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "GlobalStatus_t",
+          "original_type": "enum GlobalStatus",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    },
+    "geometry.c": {
+      "file_path": "/workspace/example/source/geometry.c",
+      "relative_path": "geometry.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "create_triangle",
+          "return_type": "triangle_t",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "c",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "triangle_area",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "tri",
+              "type": "const triangle_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "tri",
+          "type": "triangle_t",
+          "array_size": null
+        },
+        {
+          "name": "tri",
+          "type": "return",
+          "array_size": null
+        },
+        {
+          "name": "x1",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y1",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "x2",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y2",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "x3",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y3",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "area",
+          "type": "return",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "geometry.h",
+        "string.h",
+        "stdlib.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [],
+      "unions": {}
+    },
+    "geometry.h": {
+      "file_path": "/workspace/example/source/geometry.h",
+      "relative_path": "geometry.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {
+        "triangle_tag": {
+          "name": "triangle_tag",
+          "fields": [
+            {
+              "name": "vertices",
+              "type": "point_t[3]",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "char[MAX_LABEL_LEN]",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        }
+      },
+      "enums": {},
+      "functions": [
+        {
+          "name": "create_triangle",
+          "return_type": "triangle_t",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "c",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "triangle_area",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "tri",
+              "type": "const triangle_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [],
+      "includes": [
+        "sample.h",
+        "math_utils.h"
+      ],
+      "macros": [
+        "GEOMETRY_H"
+      ],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [],
+      "unions": {}
+    },
+    "logger.c": {
+      "file_path": "/workspace/example/source/logger.c",
+      "relative_path": "logger.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "set_log_callback",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "cb",
+              "type": "log_callback_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "log_message",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "level",
+              "type": "log_level_t",
+              "array_size": null
+            },
+            {
+              "name": "fmt",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "current_cb",
+          "type": "log_callback_t",
+          "array_size": null
+        },
+        {
+          "name": "args",
+          "type": "va_list",
+          "array_size": null
+        },
+        {
+          "name": "level_str",
+          "type": "const char *",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "logger.h",
+        "stdarg.h",
+        "string.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [],
+      "unions": {}
+    },
+    "logger.h": {
+      "file_path": "/workspace/example/source/logger.h",
+      "relative_path": "logger.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {
+        "log_level_tag": {
+          "name": "log_level_tag",
+          "values": [
+            "LOG_DEBUG",
+            "LOG_INFO",
+            "LOG_WARN",
+            "LOG_ERROR"
+          ]
+        }
+      },
+      "functions": [
+        {
+          "name": "set_log_callback",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "cb",
+              "type": "log_callback_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "log_message",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "level",
+              "type": "log_level_t",
+              "array_size": null
+            },
+            {
+              "name": "fmt",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [],
+      "includes": [
+        "stdio.h",
+        "config.h"
+      ],
+      "macros": [
+        "LOGGER_H"
+      ],
+      "typedefs": {
+        "log_level_t": "enum log_level_tag { LOG_DEBUG = 0, LOG_INFO, LOG_WARN, LOG_ERROR }",
+        "log_callback_t": "void (*)(...)"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "log_level_t",
+          "original_type": "enum log_level_tag { LOG_DEBUG = 0, LOG_INFO, LOG_WARN, LOG_ERROR }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "log_callback_t",
+          "original_type": "void (*)(...)",
+          "relationship_type": "alias"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    },
+    "math_utils.c": {
+      "file_path": "/workspace/example/source/math_utils.c",
+      "relative_path": "math_utils.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "add",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "subtract",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "average",
+          "return_type": "real_t",
+          "parameters": [
+            {
+              "name": "arr",
+              "type": "const int *",
+              "array_size": null
+            },
+            {
+              "name": "len",
+              "type": "size_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "b",
+          "type": "return a +",
+          "array_size": null
+        },
+        {
+          "name": "b",
+          "type": "return a -",
+          "array_size": null
+        },
+        {
+          "name": "sum",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "i",
+          "type": "size_t",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "math_utils.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [],
+      "unions": {}
+    },
+    "math_utils.h": {
+      "file_path": "/workspace/example/source/math_utils.h",
+      "relative_path": "math_utils.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "add",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "subtract",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "average",
+          "return_type": "real_t",
+          "parameters": [
+            {
+              "name": "arr",
+              "type": "const int *",
+              "array_size": null
+            },
+            {
+              "name": "len",
+              "type": "size_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [],
+      "includes": [
+        "config.h"
+      ],
+      "macros": [
+        "MATH_UTILS_H"
+      ],
+      "typedefs": {
+        "real_t": "double",
+        "math_op_t": "int (*)(...)"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "real_t",
+          "original_type": "double",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "math_op_t",
+          "original_type": "int (*)(...)",
+          "relationship_type": "alias"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    },
+    "sample.c": {
+      "file_path": "/workspace/example/source/sample.c",
+      "relative_path": "sample.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "internal_helper",
+          "return_type": "static void",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "calculate_sum",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "create_point",
+          "return_type": "point_t *",
+          "parameters": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "process_point",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "p",
+              "type": "point_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "demo_triangle_usage",
+          "return_type": "void",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "main",
+          "return_type": "int",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "CALC",
+          "return_type": "return",
+          "parameters": [],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "global_counter",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "global_ptr",
+          "type": "double *",
+          "array_size": null
+        },
+        {
+          "name": "p",
+          "type": "return",
+          "array_size": null
+        },
+        {
+          "name": "a",
+          "type": "point_t",
+          "array_size": null
+        },
+        {
+          "name": "b",
+          "type": "point_t",
+          "array_size": null
+        },
+        {
+          "name": "c",
+          "type": "point_t",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "stdio.h",
+        "stdlib.h",
+        "string.h",
+        "sample.h",
+        "math_utils.h",
+        "logger.h",
+        "geometry.h"
+      ],
+      "macros": [
+        "MAX_SIZE",
+        "DEBUG_MODE",
+        "CALC"
+      ],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [],
+      "unions": {}
+    },
+    "sample.h": {
+      "file_path": "/workspace/example/source/sample.h",
+      "relative_path": "sample.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {
+        "point_tag": {
+          "name": "point_tag",
+          "fields": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "char[32]",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        }
+      },
+      "enums": {
+        "system_state_tag": {
+          "name": "system_state_tag",
+          "values": [
+            "STATE_IDLE",
+            "STATE_RUNNING",
+            "STATE_ERROR"
+          ]
+        }
+      },
+      "functions": [
+        {
+          "name": "calculate_sum",
+          "return_type": "extern int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "create_point",
+          "return_type": "extern point_t *",
+          "parameters": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "process_point",
+          "return_type": "extern void",
+          "parameters": [
+            {
+              "name": "p",
+              "type": "point_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "x",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "MAX_POINTS",
+          "type": "extern const int",
+          "array_size": null
+        },
+        {
+          "name": "DEFAULT_LABEL",
+          "type": "extern const char *",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "stddef.h",
+        "config.h",
+        "geometry.h",
+        "logger.h"
+      ],
+      "macros": [
+        "SAMPLE_H",
+        "PI",
+        "VERSION",
+        "MIN",
+        "MAX"
+      ],
+      "typedefs": {
+        "x": "struct point_tag { int",
+        "system_state_t": "enum system_state_tag { STATE_IDLE = 0, STATE_RUNNING, STATE_ERROR }"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "x",
+          "original_type": "struct point_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "system_state_t",
+          "original_type": "enum system_state_tag { STATE_IDLE = 0, STATE_RUNNING, STATE_ERROR }",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    },
+    "typedef_test.c": {
+      "file_path": "/workspace/example/source/typedef_test.c",
+      "relative_path": "typedef_test.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "log_buffer",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "buffer",
+              "type": "const MyBuffer *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "process_buffer",
+          "return_type": "MyInt",
+          "parameters": [
+            {
+              "name": "buffer",
+              "type": "MyBuffer *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "my_callback",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "buffer",
+              "type": "MyBuffer *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "create_complex",
+          "return_type": "MyComplex *",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "MyLen",
+              "array_size": null
+            },
+            {
+              "name": "name",
+              "type": "MyString",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "main",
+          "return_type": "int",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "process_buffer",
+          "return_type": "return",
+          "parameters": [],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "global_length",
+          "type": "MyLen",
+          "array_size": null
+        },
+        {
+          "name": "global_buffer",
+          "type": "MyBuffer",
+          "array_size": null
+        },
+        {
+          "name": "global_complex",
+          "type": "MyComplexPtr",
+          "array_size": null
+        },
+        {
+          "name": "complex",
+          "type": "return",
+          "array_size": null
+        },
+        {
+          "name": "buffer",
+          "type": "MyBuffer",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "typedef_test.h",
+        "complex_example.h",
+        "geometry.h",
+        "logger.h",
+        "stdlib.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [],
+      "unions": {}
+    },
+    "typedef_test.h": {
+      "file_path": "/workspace/example/source/typedef_test.h",
+      "relative_path": "typedef_test.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {
+        "MyBuffer_tag": {
+          "name": "MyBuffer_tag",
+          "fields": [
+            {
+              "name": "length",
+              "type": "MyLen",
+              "array_size": null
+            },
+            {
+              "name": "data",
+              "type": "MyString",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        },
+        "MyComplexStruct_tag": {
+          "name": "MyComplexStruct_tag",
+          "fields": [
+            {
+              "name": "id",
+              "type": "MyLen",
+              "array_size": null
+            },
+            {
+              "name": "name",
+              "type": "MyString",
+              "array_size": null
+            },
+            {
+              "name": "callback",
+              "type": "MyCallback",
+              "array_size": null
+            },
+            {
+              "name": "log_level",
+              "type": "log_level_t",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        },
+        "Point_tag": {
+          "name": "Point_tag",
+          "fields": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        },
+        "NamedStruct_tag": {
+          "name": "NamedStruct_tag",
+          "fields": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        }
+      },
+      "enums": {
+        "Color_tag": {
+          "name": "Color_tag",
+          "values": [
+            "COLOR_RED",
+            "COLOR_GREEN",
+            "COLOR_BLUE"
+          ]
+        },
+        "StatusEnum_tag": {
+          "name": "StatusEnum_tag",
+          "values": [
+            "STATUS_OK",
+            "STATUS_FAIL"
+          ]
+        }
+      },
+      "functions": [],
+      "globals": [
+        {
+          "name": "length",
+          "type": "MyLen",
+          "array_size": null
+        },
+        {
+          "name": "data",
+          "type": "MyString",
+          "array_size": null
+        },
+        {
+          "name": "id",
+          "type": "MyLen",
+          "array_size": null
+        },
+        {
+          "name": "name",
+          "type": "MyString",
+          "array_size": null
+        },
+        {
+          "name": "callback",
+          "type": "MyCallback",
+          "array_size": null
+        },
+        {
+          "name": "log_level",
+          "type": "log_level_t",
+          "array_size": null
+        },
+        {
+          "name": "x",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "a",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "b",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "i",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "f",
+          "type": "float",
+          "array_size": null
+        },
+        {
+          "name": "c",
+          "type": "char",
+          "array_size": null
+        },
+        {
+          "name": "d",
+          "type": "double",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "stdint.h",
+        "sample.h",
+        "config.h",
+        "logger.h"
+      ],
+      "macros": [
+        "TYPEDEF_TEST_H"
+      ],
+      "typedefs": {
+        "MyLen": "uint32_t",
+        "MyInt": "int32_t",
+        "MyString": "char *",
+        "length": "struct MyBuffer_tag { MyLen",
+        "MyCallback": "int (*)(...)",
+        "id": "struct MyComplexStruct_tag { MyLen",
+        "MyComplexPtr": "MyComplex *",
+        "Color_t": "enum Color_tag { COLOR_RED = 0, COLOR_GREEN, COLOR_BLUE }",
+        "Status_t": "enum StatusEnum_tag { STATUS_OK = 0, STATUS_FAIL }",
+        "x": "struct Point_tag { int",
+        "a": "struct NamedStruct_tag { int",
+        "i": "union Number_tag { int",
+        "c": "union NamedUnion_tag { char"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "MyLen",
+          "original_type": "uint32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "MyInt",
+          "original_type": "int32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "MyString",
+          "original_type": "char *",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "length",
+          "original_type": "struct MyBuffer_tag { MyLen",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "MyCallback",
+          "original_type": "int (*)(...)",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "id",
+          "original_type": "struct MyComplexStruct_tag { MyLen",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "MyComplexPtr",
+          "original_type": "MyComplex *",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "Color_t",
+          "original_type": "enum Color_tag { COLOR_RED = 0, COLOR_GREEN, COLOR_BLUE }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "Status_t",
+          "original_type": "enum StatusEnum_tag { STATUS_OK = 0, STATUS_FAIL }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "x",
+          "original_type": "struct Point_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "a",
+          "original_type": "struct NamedStruct_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "i",
+          "original_type": "union Number_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "c",
+          "original_type": "union NamedUnion_tag { char",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    }
+  },
+  "created_at": "2025-07-21T16:29:09.403418"
+}

--- a/output/model_transformed.json
+++ b/output/model_transformed.json
@@ -1,0 +1,1518 @@
+{
+  "project_name": "source",
+  "project_root": "/workspace/example/source",
+  "files": {
+    "complex_example.h": {
+      "file_path": "/workspace/example/source/complex_example.h",
+      "relative_path": "complex_example.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {
+        "CE_Status_tag": {
+          "name": "CE_Status_tag",
+          "values": [
+            "CE_STATUS_OK",
+            "CE_STATUS_WARN",
+            "CE_STATUS_FAIL"
+          ]
+        }
+      },
+      "functions": [],
+      "globals": [
+        {
+          "name": "id",
+          "type": "id_t",
+          "array_size": null
+        },
+        {
+          "name": "log_level",
+          "type": "log_level_t",
+          "array_size": null
+        },
+        {
+          "name": "info",
+          "type": "NestedInfo_t",
+          "array_size": null
+        },
+        {
+          "name": "status",
+          "type": "CE_Status_t",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "config.h",
+        "logger.h"
+      ],
+      "macros": [
+        "COMPLEX_EXAMPLE_H"
+      ],
+      "typedefs": {
+        "id": "struct NestedInfo_tag { id_t",
+        "CE_Status_t": "enum CE_Status_tag { CE_STATUS_OK = 0, CE_STATUS_WARN, CE_STATUS_FAIL }",
+        "info": "struct ComplexExample_tag { NestedInfo_t"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "id",
+          "original_type": "struct NestedInfo_tag { id_t",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "CE_Status_t",
+          "original_type": "enum CE_Status_tag { CE_STATUS_OK = 0, CE_STATUS_WARN, CE_STATUS_FAIL }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "info",
+          "original_type": "struct ComplexExample_tag { NestedInfo_t",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/complex_example.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/complex_example.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/complex_example.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/complex_example.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 2
+        }
+      ],
+      "unions": {}
+    },
+    "config.h": {
+      "file_path": "/workspace/example/source/config.h",
+      "relative_path": "config.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {
+        "GlobalStatus": {
+          "name": "GlobalStatus",
+          "values": [
+            "GS_OK",
+            "GS_ERROR",
+            "GS_UNKNOWN"
+          ]
+        }
+      },
+      "functions": [],
+      "globals": [],
+      "includes": [
+        "stddef.h",
+        "stdint.h"
+      ],
+      "macros": [
+        "CONFIG_H",
+        "PROJECT_NAME",
+        "MAX_LABEL_LEN",
+        "DEFAULT_BUFFER_SIZE"
+      ],
+      "typedefs": {
+        "id_t": "uint32_t",
+        "status_t": "int32_t",
+        "GlobalStatus_t": "enum GlobalStatus"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "id_t",
+          "original_type": "uint32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "status_t",
+          "original_type": "int32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "GlobalStatus_t",
+          "original_type": "enum GlobalStatus",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [],
+      "unions": {}
+    },
+    "geometry.c": {
+      "file_path": "/workspace/example/source/geometry.c",
+      "relative_path": "geometry.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "create_triangle",
+          "return_type": "triangle_t",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "c",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "triangle_area",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "tri",
+              "type": "const triangle_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "tri",
+          "type": "triangle_t",
+          "array_size": null
+        },
+        {
+          "name": "tri",
+          "type": "return",
+          "array_size": null
+        },
+        {
+          "name": "x1",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y1",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "x2",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y2",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "x3",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y3",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "area",
+          "type": "return",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "geometry.h",
+        "string.h",
+        "stdlib.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/geometry.c",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 1
+        }
+      ],
+      "unions": {}
+    },
+    "geometry.h": {
+      "file_path": "/workspace/example/source/geometry.h",
+      "relative_path": "geometry.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "create_triangle",
+          "return_type": "triangle_t",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "c",
+              "type": "const point_t *",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "triangle_area",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "tri",
+              "type": "const triangle_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [],
+      "includes": [
+        "sample.h",
+        "math_utils.h"
+      ],
+      "macros": [
+        "GEOMETRY_H"
+      ],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/geometry.h",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 2
+        }
+      ],
+      "unions": {}
+    },
+    "logger.c": {
+      "file_path": "/workspace/example/source/logger.c",
+      "relative_path": "logger.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "set_log_callback",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "cb",
+              "type": "log_callback_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "log_message",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "level",
+              "type": "log_level_t",
+              "array_size": null
+            },
+            {
+              "name": "fmt",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "current_cb",
+          "type": "log_callback_t",
+          "array_size": null
+        },
+        {
+          "name": "args",
+          "type": "va_list",
+          "array_size": null
+        },
+        {
+          "name": "level_str",
+          "type": "const char *",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "logger.h",
+        "stdarg.h",
+        "string.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/logger.c",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 1
+        }
+      ],
+      "unions": {}
+    },
+    "logger.h": {
+      "file_path": "/workspace/example/source/logger.h",
+      "relative_path": "logger.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {
+        "log_level_tag": {
+          "name": "log_level_tag",
+          "values": [
+            "LOG_DEBUG",
+            "LOG_INFO",
+            "LOG_WARN",
+            "LOG_ERROR"
+          ]
+        }
+      },
+      "functions": [
+        {
+          "name": "set_log_callback",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "cb",
+              "type": "log_callback_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "log_message",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "level",
+              "type": "log_level_t",
+              "array_size": null
+            },
+            {
+              "name": "fmt",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [],
+      "includes": [
+        "stdio.h",
+        "config.h"
+      ],
+      "macros": [
+        "LOGGER_H"
+      ],
+      "typedefs": {
+        "log_level_t": "enum log_level_tag { LOG_DEBUG = 0, LOG_INFO, LOG_WARN, LOG_ERROR }",
+        "log_callback_t": "void (*)(...)"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "log_level_t",
+          "original_type": "enum log_level_tag { LOG_DEBUG = 0, LOG_INFO, LOG_WARN, LOG_ERROR }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "log_callback_t",
+          "original_type": "void (*)(...)",
+          "relationship_type": "alias"
+        }
+      ],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/logger.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        }
+      ],
+      "unions": {}
+    },
+    "math_utils.c": {
+      "file_path": "/workspace/example/source/math_utils.c",
+      "relative_path": "math_utils.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "add",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "subtract",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "average",
+          "return_type": "real_t",
+          "parameters": [
+            {
+              "name": "arr",
+              "type": "const int *",
+              "array_size": null
+            },
+            {
+              "name": "len",
+              "type": "size_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "b",
+          "type": "return a +",
+          "array_size": null
+        },
+        {
+          "name": "b",
+          "type": "return a -",
+          "array_size": null
+        },
+        {
+          "name": "sum",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "i",
+          "type": "size_t",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "math_utils.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/math_utils.c",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 1
+        }
+      ],
+      "unions": {}
+    },
+    "math_utils.h": {
+      "file_path": "/workspace/example/source/math_utils.h",
+      "relative_path": "math_utils.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "add",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "subtract",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "average",
+          "return_type": "real_t",
+          "parameters": [
+            {
+              "name": "arr",
+              "type": "const int *",
+              "array_size": null
+            },
+            {
+              "name": "len",
+              "type": "size_t",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [],
+      "includes": [
+        "config.h"
+      ],
+      "macros": [
+        "MATH_UTILS_H"
+      ],
+      "typedefs": {
+        "real_t": "double",
+        "math_op_t": "int (*)(...)"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "real_t",
+          "original_type": "double",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "math_op_t",
+          "original_type": "int (*)(...)",
+          "relationship_type": "alias"
+        }
+      ],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/math_utils.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/math_utils.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/math_utils.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/math_utils.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        }
+      ],
+      "unions": {}
+    },
+    "sample.c": {
+      "file_path": "/workspace/example/source/sample.c",
+      "relative_path": "sample.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "calculate_sum",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "create_point",
+          "return_type": "point_t *",
+          "parameters": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "process_point",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "p",
+              "type": "point_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "demo_triangle_usage",
+          "return_type": "void",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "main",
+          "return_type": "int",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "CALC",
+          "return_type": "return",
+          "parameters": [],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "global_counter",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "global_ptr",
+          "type": "double *",
+          "array_size": null
+        },
+        {
+          "name": "p",
+          "type": "return",
+          "array_size": null
+        },
+        {
+          "name": "a",
+          "type": "point_t",
+          "array_size": null
+        },
+        {
+          "name": "b",
+          "type": "point_t",
+          "array_size": null
+        },
+        {
+          "name": "c",
+          "type": "point_t",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "stdio.h",
+        "stdlib.h",
+        "string.h",
+        "sample.h",
+        "math_utils.h",
+        "logger.h",
+        "geometry.h"
+      ],
+      "macros": [
+        "MAX_SIZE",
+        "DEBUG_MODE",
+        "CALC"
+      ],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/sample.c",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/sample.c",
+          "included_file": "/workspace/example/source/math_utils.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/sample.c",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/sample.c",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 1
+        }
+      ],
+      "unions": {}
+    },
+    "sample.h": {
+      "file_path": "/workspace/example/source/sample.h",
+      "relative_path": "sample.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {
+        "point_tag": {
+          "name": "point_tag",
+          "fields": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "char[32]",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        }
+      },
+      "enums": {
+        "system_state_tag": {
+          "name": "system_state_tag",
+          "values": [
+            "STATE_IDLE",
+            "STATE_RUNNING",
+            "STATE_ERROR"
+          ]
+        }
+      },
+      "functions": [
+        {
+          "name": "calculate_sum",
+          "return_type": "extern int",
+          "parameters": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "create_point",
+          "return_type": "extern point_t *",
+          "parameters": [
+            {
+              "name": "x",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "y",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "label",
+              "type": "const char *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "process_point",
+          "return_type": "extern void",
+          "parameters": [
+            {
+              "name": "p",
+              "type": "point_t *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "x",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "MAX_POINTS",
+          "type": "extern const int",
+          "array_size": null
+        },
+        {
+          "name": "DEFAULT_LABEL",
+          "type": "extern const char *",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "stddef.h",
+        "config.h",
+        "geometry.h",
+        "logger.h"
+      ],
+      "macros": [
+        "SAMPLE_H",
+        "PI",
+        "VERSION",
+        "MIN",
+        "MAX"
+      ],
+      "typedefs": {
+        "x": "struct point_tag { int",
+        "system_state_t": "enum system_state_tag { STATE_IDLE = 0, STATE_RUNNING, STATE_ERROR }"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "x",
+          "original_type": "struct point_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "system_state_t",
+          "original_type": "enum system_state_tag { STATE_IDLE = 0, STATE_RUNNING, STATE_ERROR }",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/sample.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 2
+        }
+      ],
+      "unions": {}
+    },
+    "typedef_test.c": {
+      "file_path": "/workspace/example/source/typedef_test.c",
+      "relative_path": "typedef_test.c",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {},
+      "enums": {},
+      "functions": [
+        {
+          "name": "log_buffer",
+          "return_type": "void",
+          "parameters": [
+            {
+              "name": "buffer",
+              "type": "const MyBuffer *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "process_buffer",
+          "return_type": "MyInt",
+          "parameters": [
+            {
+              "name": "buffer",
+              "type": "MyBuffer *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "my_callback",
+          "return_type": "int",
+          "parameters": [
+            {
+              "name": "buffer",
+              "type": "MyBuffer *",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "create_complex",
+          "return_type": "MyComplex *",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "MyLen",
+              "array_size": null
+            },
+            {
+              "name": "name",
+              "type": "MyString",
+              "array_size": null
+            }
+          ],
+          "is_static": false
+        },
+        {
+          "name": "main",
+          "return_type": "int",
+          "parameters": [],
+          "is_static": false
+        },
+        {
+          "name": "process_buffer",
+          "return_type": "return",
+          "parameters": [],
+          "is_static": false
+        }
+      ],
+      "globals": [
+        {
+          "name": "global_length",
+          "type": "MyLen",
+          "array_size": null
+        },
+        {
+          "name": "global_buffer",
+          "type": "MyBuffer",
+          "array_size": null
+        },
+        {
+          "name": "global_complex",
+          "type": "MyComplexPtr",
+          "array_size": null
+        },
+        {
+          "name": "complex",
+          "type": "return",
+          "array_size": null
+        },
+        {
+          "name": "buffer",
+          "type": "MyBuffer",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "typedef_test.h",
+        "complex_example.h",
+        "geometry.h",
+        "logger.h",
+        "stdlib.h"
+      ],
+      "macros": [],
+      "typedefs": {},
+      "typedef_relations": [],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/typedef_test.c",
+          "included_file": "/workspace/example/source/typedef_test.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.c",
+          "included_file": "/workspace/example/source/complex_example.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.c",
+          "included_file": "/workspace/example/source/geometry.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.c",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 1
+        }
+      ],
+      "unions": {}
+    },
+    "typedef_test.h": {
+      "file_path": "/workspace/example/source/typedef_test.h",
+      "relative_path": "typedef_test.h",
+      "project_root": "/workspace/example/source",
+      "encoding_used": "utf-8",
+      "structs": {
+        "MyComplexStruct_tag": {
+          "name": "MyComplexStruct_tag",
+          "fields": [
+            {
+              "name": "id",
+              "type": "MyLen",
+              "array_size": null
+            },
+            {
+              "name": "name",
+              "type": "MyString",
+              "array_size": null
+            },
+            {
+              "name": "callback",
+              "type": "MyCallback",
+              "array_size": null
+            },
+            {
+              "name": "log_level",
+              "type": "log_level_t",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        },
+        "NamedStruct_tag": {
+          "name": "NamedStruct_tag",
+          "fields": [
+            {
+              "name": "a",
+              "type": "int",
+              "array_size": null
+            },
+            {
+              "name": "b",
+              "type": "int",
+              "array_size": null
+            }
+          ],
+          "methods": []
+        }
+      },
+      "enums": {
+        "Color_tag": {
+          "name": "Color_tag",
+          "values": [
+            "COLOR_RED",
+            "COLOR_GREEN",
+            "COLOR_BLUE"
+          ]
+        },
+        "StatusEnum_tag": {
+          "name": "StatusEnum_tag",
+          "values": [
+            "STATUS_OK",
+            "STATUS_FAIL"
+          ]
+        }
+      },
+      "functions": [],
+      "globals": [
+        {
+          "name": "length",
+          "type": "MyLen",
+          "array_size": null
+        },
+        {
+          "name": "data",
+          "type": "MyString",
+          "array_size": null
+        },
+        {
+          "name": "id",
+          "type": "MyLen",
+          "array_size": null
+        },
+        {
+          "name": "name",
+          "type": "MyString",
+          "array_size": null
+        },
+        {
+          "name": "callback",
+          "type": "MyCallback",
+          "array_size": null
+        },
+        {
+          "name": "log_level",
+          "type": "log_level_t",
+          "array_size": null
+        },
+        {
+          "name": "x",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "y",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "a",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "b",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "i",
+          "type": "int",
+          "array_size": null
+        },
+        {
+          "name": "f",
+          "type": "float",
+          "array_size": null
+        },
+        {
+          "name": "c",
+          "type": "char",
+          "array_size": null
+        },
+        {
+          "name": "d",
+          "type": "double",
+          "array_size": null
+        }
+      ],
+      "includes": [
+        "stdint.h",
+        "sample.h",
+        "config.h",
+        "logger.h"
+      ],
+      "macros": [
+        "TYPEDEF_TEST_H"
+      ],
+      "typedefs": {
+        "MyLen": "uint32_t",
+        "MyInt": "int32_t",
+        "MyString": "char *",
+        "length": "struct MyBuffer_tag { MyLen",
+        "MyCallback": "int (*)(...)",
+        "id": "struct MyComplexStruct_tag { MyLen",
+        "MyComplexPtr": "MyComplex *",
+        "Color_t": "enum Color_tag { COLOR_RED = 0, COLOR_GREEN, COLOR_BLUE }",
+        "Status_t": "enum StatusEnum_tag { STATUS_OK = 0, STATUS_FAIL }",
+        "x": "struct Point_tag { int",
+        "a": "struct NamedStruct_tag { int",
+        "i": "union Number_tag { int",
+        "c": "union NamedUnion_tag { char"
+      },
+      "typedef_relations": [
+        {
+          "typedef_name": "MyLen",
+          "original_type": "uint32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "MyInt",
+          "original_type": "int32_t",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "MyString",
+          "original_type": "char *",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "length",
+          "original_type": "struct MyBuffer_tag { MyLen",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "MyCallback",
+          "original_type": "int (*)(...)",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "id",
+          "original_type": "struct MyComplexStruct_tag { MyLen",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "MyComplexPtr",
+          "original_type": "MyComplex *",
+          "relationship_type": "alias"
+        },
+        {
+          "typedef_name": "Color_t",
+          "original_type": "enum Color_tag { COLOR_RED = 0, COLOR_GREEN, COLOR_BLUE }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "Status_t",
+          "original_type": "enum StatusEnum_tag { STATUS_OK = 0, STATUS_FAIL }",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "x",
+          "original_type": "struct Point_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "a",
+          "original_type": "struct NamedStruct_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "i",
+          "original_type": "union Number_tag { int",
+          "relationship_type": "defines"
+        },
+        {
+          "typedef_name": "c",
+          "original_type": "union NamedUnion_tag { char",
+          "relationship_type": "defines"
+        }
+      ],
+      "include_relations": [
+        {
+          "source_file": "/workspace/example/source/typedef_test.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 2
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.h",
+          "included_file": "/workspace/example/source/sample.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.h",
+          "included_file": "/workspace/example/source/config.h",
+          "depth": 1
+        },
+        {
+          "source_file": "/workspace/example/source/typedef_test.h",
+          "included_file": "/workspace/example/source/logger.h",
+          "depth": 1
+        }
+      ],
+      "unions": {}
+    }
+  },
+  "created_at": "2025-07-21T16:29:09.403418"
+}

--- a/output/sample.puml
+++ b/output/sample.puml
@@ -1,0 +1,89 @@
+@startuml sample
+
+class "sample" as SAMPLE <<source>> #LightBlue
+{
+    -- Macros --
+    - #define MAX_SIZE
+    - #define DEBUG_MODE
+    - #define CALC
+    -- Typedefs --
+    + typedef double real_t
+    + typedef int (*)(...) math_op_t
+    + typedef void (*)(...) log_callback_t
+    -- Global Variables --
+    int global_counter
+    double * global_ptr
+    return p
+    point_t a
+    point_t b
+    point_t c
+    -- Functions --
+    int calculate_sum()
+    point_t * create_point()
+    void process_point()
+    void demo_triangle_usage()
+    int main()
+    return CALC()
+}
+
+class "sample" as HEADER_SAMPLE <<header>> #LightGreen
+{
+    -- Macros --
+    + #define SAMPLE_H
+    + #define PI
+    + #define VERSION
+    + #define MIN
+    + #define MAX
+    -- Global Variables --
+    + int x
+    + int y
+    + extern const int MAX_POINTS
+    + extern const char * DEFAULT_LABEL
+    -- Functions --
+    + extern int calculate_sum()
+    + extern point_t * create_point()
+    + extern void process_point()
+}
+
+class "math_utils" as HEADER_MATH_UTILS <<header>> #LightGreen
+{
+    -- Macros --
+    + #define MATH_UTILS_H
+    -- Typedefs --
+    + typedef double real_t
+    + typedef int (*)(...) math_op_t
+    -- Functions --
+    + int add()
+    + int subtract()
+    + real_t average()
+}
+
+class "logger" as HEADER_LOGGER <<header>> #LightGreen
+{
+    -- Macros --
+    + #define LOGGER_H
+    -- Typedefs --
+    + typedef void (*)(...) log_callback_t
+    -- Functions --
+    + void set_log_callback()
+    + void log_message()
+}
+
+class "geometry" as HEADER_GEOMETRY <<header>> #LightGreen
+{
+    -- Macros --
+    + #define GEOMETRY_H
+    -- Functions --
+    + triangle_t create_triangle()
+    + int triangle_area()
+}
+
+SAMPLE --> HEADER_SAMPLE : <<include>>
+SAMPLE --> HEADER_MATH_UTILS : <<include>>
+SAMPLE --> HEADER_LOGGER : <<include>>
+SAMPLE --> HEADER_GEOMETRY : <<include>>
+HEADER_SAMPLE --> HEADER_MATH_UTILS : <<include>>
+HEADER_SAMPLE --> HEADER_LOGGER : <<include>>
+HEADER_SAMPLE --> HEADER_GEOMETRY : <<include>>
+
+@enduml

--- a/output/typedef_test.puml
+++ b/output/typedef_test.puml
@@ -1,0 +1,93 @@
+@startuml typedef_test
+
+class "typedef_test" as TYPEDEF_TEST <<source>> #LightBlue
+{
+    -- Typedefs --
+    + typedef uint32_t MyLen
+    + typedef int32_t MyInt
+    + typedef char * MyString
+    + typedef int (*)(...) MyCallback
+    + typedef MyComplex * MyComplexPtr
+    + typedef void (*)(...) log_callback_t
+    -- Global Variables --
+    MyLen global_length
+    MyBuffer global_buffer
+    MyComplexPtr global_complex
+    return complex
+    MyBuffer buffer
+    -- Functions --
+    void log_buffer()
+    MyInt process_buffer()
+    int my_callback()
+    MyComplex * create_complex()
+    int main()
+    return process_buffer()
+}
+
+class "typedef_test" as HEADER_TYPEDEF_TEST <<header>> #LightGreen
+{
+    -- Macros --
+    + #define TYPEDEF_TEST_H
+    -- Typedefs --
+    + typedef uint32_t MyLen
+    + typedef int32_t MyInt
+    + typedef char * MyString
+    + typedef int (*)(...) MyCallback
+    + typedef MyComplex * MyComplexPtr
+    -- Global Variables --
+    + MyLen length
+    + MyString data
+    + MyLen id
+    + MyString name
+    + MyCallback callback
+    + log_level_t log_level
+    + int x
+    + int y
+    + int a
+    + int b
+    + int i
+    + float f
+    + char c
+    + double d
+}
+
+class "complex_example" as HEADER_COMPLEX_EXAMPLE <<header>> #LightGreen
+{
+    -- Macros --
+    + #define COMPLEX_EXAMPLE_H
+    -- Global Variables --
+    + id_t id
+    + log_level_t log_level
+    + NestedInfo_t info
+    + CE_Status_t status
+}
+
+class "geometry" as HEADER_GEOMETRY <<header>> #LightGreen
+{
+    -- Macros --
+    + #define GEOMETRY_H
+    -- Functions --
+    + triangle_t create_triangle()
+    + int triangle_area()
+}
+
+class "logger" as HEADER_LOGGER <<header>> #LightGreen
+{
+    -- Macros --
+    + #define LOGGER_H
+    -- Typedefs --
+    + typedef void (*)(...) log_callback_t
+    -- Functions --
+    + void set_log_callback()
+    + void log_message()
+}
+
+TYPEDEF_TEST --> HEADER_TYPEDEF_TEST : <<include>>
+TYPEDEF_TEST --> HEADER_COMPLEX_EXAMPLE : <<include>>
+TYPEDEF_TEST --> HEADER_GEOMETRY : <<include>>
+TYPEDEF_TEST --> HEADER_LOGGER : <<include>>
+HEADER_TYPEDEF_TEST --> HEADER_COMPLEX_EXAMPLE : <<include>>
+HEADER_TYPEDEF_TEST --> HEADER_GEOMETRY : <<include>>
+HEADER_TYPEDEF_TEST --> HEADER_LOGGER : <<include>>
+
+@enduml


### PR DESCRIPTION
Track generated output files in `output/` by updating `.gitignore`.

The `run_example.sh` script's output (PlantUML and JSON files) was previously ignored by git's `*.puml` and `*.json` patterns. This PR adds exceptions to allow tracking within the `output/` directory.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e7014b5d-84a0-4fed-85a8-bd5a807ea3af) · [Cursor](https://cursor.com/background-agent?bcId=bc-e7014b5d-84a0-4fed-85a8-bd5a807ea3af)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)