### PR TITLE
Fix github workflow deployment and coverage updates

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -61,23 +61,32 @@ jobs:
           cp README.md docs/
         fi
         
-        # Copy test reports and coverage files
-        if [ -d "tests/reports" ]; then
-          mkdir -p docs/tests/reports
+        # Copy test reports and coverage files from artifacts directory
+        if [ -d "artifacts/test_reports" ]; then
+          mkdir -p docs/artifacts/test_reports
           # Copy all test report files
-          cp -r tests/reports/* docs/tests/reports/
-          echo "✅ Test reports copied to docs/tests/reports/"
+          cp -r artifacts/test_reports/* docs/artifacts/test_reports/
+          echo "✅ Test reports copied to docs/artifacts/test_reports/"
+        fi
+        
+        if [ -d "artifacts/coverage" ]; then
+          mkdir -p docs/artifacts/coverage
+          # Copy all coverage files
+          cp -r artifacts/coverage/* docs/artifacts/coverage/
+          echo "✅ Coverage reports copied to docs/artifacts/coverage/"
           
           # Verify htmlcov folder is properly copied
-          if [ -d "docs/tests/reports/coverage/htmlcov" ]; then
+          if [ -d "docs/artifacts/coverage/htmlcov" ]; then
             echo "✅ htmlcov folder found in deployment"
             echo "📊 htmlcov contents:"
-            ls -la docs/tests/reports/coverage/htmlcov/
-            echo "📊 htmlcov file count: $(find docs/tests/reports/coverage/htmlcov -type f | wc -l)"
+            ls -la docs/artifacts/coverage/htmlcov/
+            echo "📊 htmlcov file count: $(find docs/artifacts/coverage/htmlcov -type f | wc -l)"
           else
             echo "⚠️ htmlcov folder not found in deployment"
             echo "🔍 Checking coverage directory contents:"
-            ls -la docs/tests/reports/coverage/
+            if [ -d "docs/artifacts/coverage" ]; then
+              ls -la docs/artifacts/coverage/
+            fi
           fi
         fi
         
@@ -112,17 +121,17 @@ jobs:
         find docs -type f | sort
         echo ""
         echo "📊 Test report files:"
-        find docs/tests/reports -type f | sort
+        find docs/artifacts/test_reports -type f | sort 2>/dev/null || echo "No test report files found"
         echo ""
         echo "📊 Coverage files:"
-        find docs/tests/reports/coverage -type f | sort
+        find docs/artifacts/coverage -type f | sort 2>/dev/null || echo "No coverage files found"
         echo ""
         echo "📊 htmlcov folder verification:"
-        if [ -d "docs/tests/reports/coverage/htmlcov" ]; then
+        if [ -d "docs/artifacts/coverage/htmlcov" ]; then
           echo "✅ htmlcov folder exists"
           echo "📊 htmlcov files:"
-          find docs/tests/reports/coverage/htmlcov -type f | sort
-          echo "📊 htmlcov index.html exists: $(test -f docs/tests/reports/coverage/htmlcov/index.html && echo 'YES' || echo 'NO')"
+          find docs/artifacts/coverage/htmlcov -type f | sort
+          echo "📊 htmlcov index.html exists: $(test -f docs/artifacts/coverage/htmlcov/index.html && echo 'YES' || echo 'NO')"
         else
           echo "❌ htmlcov folder missing"
         fi
@@ -160,8 +169,8 @@ jobs:
             <div class="container">
                 <div class="nav">
                     <a href="index.html">🏠 Home</a>
-                    <a href="tests/reports/coverage/htmlcov/index.html">📊 Coverage</a>
-                    <a href="tests/reports/test_summary.html">📝 Tests</a>
+                    <a href="artifacts/coverage/htmlcov/index.html">📊 Coverage</a>
+                    <a href="artifacts/test_reports/test_summary.html">📝 Tests</a>
                     <a href="artifacts/output_example/diagram_index.html">📊 Diagrams</a>
                     <a href="https://github.com/fischerjooo/c2puml/tree/main/tests/example">📋 Example</a>
                 </div>
@@ -176,8 +185,8 @@ jobs:
                     <div class="card">
                         <h3>📊 Test Coverage & Reports</h3>
                         <p>View comprehensive test coverage reports and execution summaries.</p>
-                        <a href="tests/reports/coverage/htmlcov/index.html" class="btn">📊 View Coverage</a>
-                        <a href="tests/reports/test_summary.html" class="btn">📝 Test Summary</a>
+                        <a href="artifacts/coverage/htmlcov/index.html" class="btn">📊 View Coverage</a>
+                        <a href="artifacts/test_reports/test_summary.html" class="btn">📝 Test Summary</a>
                     </div>
                     
                     <div class="card">
@@ -343,8 +352,8 @@ jobs:
         
         echo "### 🔗 Quick Links" >> $GITHUB_STEP_SUMMARY
         echo "- [🏠 Home Page](https://${{ github.repository_owner }}.github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/)" >> $GITHUB_STEP_SUMMARY
-        echo "- [📊 Coverage Report](https://${{ github.repository_owner }}.github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/tests/reports/coverage/htmlcov/)" >> $GITHUB_STEP_SUMMARY
-        echo "- [📝 Test Summary](https://${{ github.repository_owner }}.github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/tests/reports/test_summary.html)" >> $GITHUB_STEP_SUMMARY
+        echo "- [📊 Coverage Report](https://${{ github.repository_owner }}.github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/artifacts/coverage/htmlcov/)" >> $GITHUB_STEP_SUMMARY
+        echo "- [📝 Test Summary](https://${{ github.repository_owner }}.github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/artifacts/test_reports/test_summary.html)" >> $GITHUB_STEP_SUMMARY
         echo "- [📊 Diagrams](https://${{ github.repository_owner }}.github.io/$(echo ${{ github.repository }} | cut -d'/' -f2)/artifacts/output_example/diagram_index.html)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -143,12 +143,12 @@ jobs:
             echo "📁 Adding coverage reports to git..."
             git add artifacts/test_reports/
             
-            # Ensure HTML coverage reports are included
-            if [ -d "artifacts/coverage/htmlcov" ]; then
-              echo "📁 Adding HTML coverage reports..."
-              git add artifacts/coverage/htmlcov/
+            # Ensure all coverage reports are included
+            if [ -d "artifacts/coverage" ]; then
+              echo "📁 Adding coverage reports..."
+              git add artifacts/coverage/
             else
-              echo "⚠️ HTML coverage reports directory not found"
+              echo "⚠️ Coverage reports directory not found"
             fi
 
             # Check if there are changes to commit
@@ -237,13 +237,16 @@ jobs:
                       
                       # For coverage reports, prefer our changes
                       git add artifacts/test_reports/ || true
+                      git add artifacts/coverage/ || true
                       if ! git cherry-pick --continue; then
                         echo "⚠️ Manual resolution required, using force strategy..."
                         git cherry-pick --abort
                         
                         # Copy our changes manually
                         git checkout "$COMMIT_HASH" -- artifacts/test_reports/ || true
+                        git checkout "$COMMIT_HASH" -- artifacts/coverage/ || true
                         git add artifacts/test_reports/ || true
+                        git add artifacts/coverage/ || true
                         
                         if git diff --staged --quiet; then
                           echo "ℹ️ No changes to commit after conflict resolution"
@@ -262,6 +265,7 @@ jobs:
                       
                       # For coverage reports, prefer our changes
                       git add artifacts/test_reports/ || true
+                      git add artifacts/coverage/ || true
                       if ! git rebase --continue; then
                         echo "⚠️ Rebase failed, trying merge strategy..."
                         git rebase --abort
@@ -272,6 +276,7 @@ jobs:
                           git merge --abort || true
                           git reset --hard "origin/$TARGET_BRANCH"
                           git add artifacts/test_reports/
+                          git add artifacts/coverage/
                           git commit -F /tmp/commit_msg || true
                         }
                       fi
@@ -373,6 +378,29 @@ jobs:
           echo "- Event: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- Ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
           echo "- Workflow: ${{ github.workflow }} #${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: 🚀 Trigger Website Deployment
+        if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // This step triggers the deploy-website workflow after successful test completion
+            try {
+              const { data: runs } = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'deploy-website.yml',
+                ref: context.ref,
+                inputs: {
+                  message: 'Deploy updated coverage reports from test-coverage workflow'
+                }
+              });
+              console.log('✅ Website deployment workflow triggered successfully');
+            } catch (error) {
+              console.log('⚠️ Failed to trigger website deployment workflow:', error.message);
+              console.log('💡 Website deployment can be triggered manually if needed');
+              // Don't fail the workflow if deployment trigger fails
+            }
 
       - name: 🖼️ Trigger PlantUML to PNG Conversion
         if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')

--- a/scripts/generate_combined_coverage.py
+++ b/scripts/generate_combined_coverage.py
@@ -109,8 +109,8 @@ def main():
     )
     parser.add_argument(
         "--output-dir",
-        default="tests/reports/coverage",
-        help="Output directory for coverage reports (default: tests/reports/coverage)",
+        default="artifacts/coverage",
+        help="Output directory for coverage reports (default: artifacts/coverage)",
     )
     parser.add_argument(
         "--run-tests",

--- a/scripts/picgen.sh
+++ b/scripts/picgen.sh
@@ -444,8 +444,8 @@ generate_diagram_index() {
     <div class="container">
         <div class="nav">
             <a href="../index.html">🏠 Home</a>
-            <a href="../tests/reports/coverage/htmlcov/index.html">📊 Coverage</a>
-            <a href="../tests/reports/test_summary.html">📝 Tests</a>
+            <a href="../artifacts/coverage/htmlcov/index.html">📊 Coverage</a>
+            <a href="../artifacts/test_reports/test_summary.html">📝 Tests</a>
             <span style="background: rgba(255,255,255,0.2); padding: 5px 10px; border-radius: 4px;">📊 Diagrams</span>
             <a href="https://github.com/fischerjooo/c2puml/tree/main/tests/example">📋 Example</a>
         </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes GitHub workflow paths and triggers to resolve 404 errors for deployed coverage artifacts and ensure automatic updates.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, coverage and test reports were generated in `artifacts/` but the `deploy-website.yml` workflow and some internal navigation links expected them in `tests/reports/`. This PR standardizes the paths to `artifacts/` across all relevant workflows and scripts, and adds an automatic deployment trigger from the `test-coverage` workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d7d270c-907f-4201-8013-7fa30f975208">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d7d270c-907f-4201-8013-7fa30f975208">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>