### PR TITLE
Fix github workflow execution order

### DIFF
--- a/.github/workflows/01-test-and-coverage.yml
+++ b/.github/workflows/01-test-and-coverage.yml
@@ -82,14 +82,20 @@ jobs:
         retention-days: 30
 
     - name: "01.12 Trigger PlantUML generation"
-      if: success()
+      if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
       uses: actions/github-script@v7
       with:
         script: |
           console.log('🚀 Triggering PlantUML generation workflow...');
-          await github.rest.actions.createWorkflowDispatch({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: '02-puml-to-png.yml',
-            ref: context.ref
-          });
+          try {
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '02-puml-to-png.yml',
+              ref: context.ref
+            });
+            console.log('✅ Successfully triggered PlantUML generation workflow');
+          } catch (error) {
+            console.error('❌ Failed to trigger PlantUML generation workflow:', error);
+            core.setFailed('Failed to trigger PlantUML generation workflow');
+          }

--- a/.github/workflows/02-puml-to-png.yml
+++ b/.github/workflows/02-puml-to-png.yml
@@ -14,12 +14,6 @@ on:
         description: 'Output folder containing .puml files'
         required: false
         type: string
-  push:
-    paths:
-      - 'artifacts/output_example/**/*.puml'
-      - 'picgen.sh'
-      - '.github/workflows/02-puml-to-png.yml'
-    branches: [main, master]
 
 jobs:
   generate-plantuml:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,7 +42,6 @@ This repository uses a streamlined, numbered workflow system that follows a clea
 **Triggers**:
 - Called by workflow 01 (main branch only)
 - Manual dispatch
-- Push to PlantUML files on main/master
 
 **Steps**:
 1. **02.01-02.02**: Setup environment and Git configuration
@@ -81,7 +80,7 @@ Pull Request → 00. Test
 ### Main Branch
 ```
 Main Branch Push (source code) → 01. Test and Coverage
-    ↓ (if successful)
+    ↓ (if successful and on main/master)
     02. PlantUML to PNG
     ↓ (commits generated files to main)
     03. Deploy Website


### PR DESCRIPTION
Ensure PlantUML generation workflow runs sequentially after successful tests on the main branch.

Previously, the "Test and Coverage" and "PlantUML to PNG" workflows were triggered simultaneously on `main` branch pushes. This PR modifies the PlantUML workflow to be triggered only by `workflow_dispatch` or `workflow_call`, and updates the test workflow to explicitly call the PlantUML generation only after all tests pass and on the `main`/`master` branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-97f88a2b-773b-46af-9197-b97d03f8fe90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97f88a2b-773b-46af-9197-b97d03f8fe90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>