### PR TITLE
Fix github workflows and checkout errors

### DIFF
--- a/.github/workflows/10-release.yml
+++ b/.github/workflows/10-release.yml
@@ -3,11 +3,6 @@ name: 10. Release
 on:
   workflow_dispatch:
     inputs:
-      release_date:
-        description: 'Release date (YYYY-MM-DD format)'
-        required: false
-        default: ''
-        type: string
       release_suffix:
         description: 'Optional suffix to append to tag name (e.g., "beta", "rc1")'
         required: false
@@ -45,11 +40,8 @@ jobs:
       - name: "10.04 Generate release date and tag"
         id: release_date
         run: |
-          if [ -n "${{ github.event.inputs.release_date }}" ]; then
-            echo "date=${{ github.event.inputs.release_date }}" >> $GITHUB_OUTPUT
-          else
-            echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
-          fi
+          # Always use current date
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
           
           # Build tag name with optional suffix
           TAG_NAME="v${{ steps.release_date.outputs.date }}"

--- a/.github/workflows/10-release.yml
+++ b/.github/workflows/10-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: 10. Release
 
 on:
   workflow_dispatch:
@@ -73,6 +73,9 @@ jobs:
 
       - name: "10.06 Copy files from main branch"
         run: |
+          # Stash any changes to avoid checkout conflicts
+          git stash || true
+          
           # Switch back to main to copy files
           git checkout main
           


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Release workflow name to '10. Release' and add `git stash` to prevent checkout conflicts.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `10.06 Copy files from main branch` step was failing because `artifacts/output_example/diagram_index.html` had uncommitted changes, preventing the `git checkout main` operation. Adding `git stash || true` ensures any local changes are temporarily saved, allowing the branch switch to proceed without error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7cc82d5-f5ab-48fa-9721-aa741282dbdb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7cc82d5-f5ab-48fa-9721-aa741282dbdb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>