### PR TITLE
Clean git history on main and release

### DIFF
--- a/.github/workflows/11-clean-history.yml
+++ b/.github/workflows/11-clean-history.yml
@@ -1,0 +1,168 @@
+name: 11. Clean History
+
+on:
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: 'Branches to clean (comma-separated, e.g., "main,release")'
+        required: false
+        default: 'main,release'
+        type: string
+      commit_count:
+        description: 'Number of commits to keep'
+        required: false
+        default: '50'
+        type: string
+      dry_run:
+        description: 'Perform a dry run without making changes'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  clean-history:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: "11.01 Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "11.02 Configure Git"
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: "11.03 Validate inputs"
+        id: validate
+        run: |
+          BRANCHES="${{ github.event.inputs.branches }}"
+          COMMIT_COUNT="${{ github.event.inputs.commit_count }}"
+          DRY_RUN="${{ github.event.inputs.dry_run }}"
+          
+          # Validate commit count is a positive integer
+          if ! [[ "$COMMIT_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "❌ Error: commit_count must be a positive integer"
+            exit 1
+          fi
+          
+          # Validate commit count is reasonable (between 1 and 1000)
+          if [ "$COMMIT_COUNT" -lt 1 ] || [ "$COMMIT_COUNT" -gt 1000 ]; then
+            echo "❌ Error: commit_count must be between 1 and 1000"
+            exit 1
+          fi
+          
+          echo "branches=${BRANCHES}" >> $GITHUB_OUTPUT
+          echo "commit_count=${COMMIT_COUNT}" >> $GITHUB_OUTPUT
+          echo "dry_run=${DRY_RUN}" >> $GITHUB_OUTPUT
+          
+          echo "✅ Configuration validated:"
+          echo "  - Branches: ${BRANCHES}"
+          echo "  - Commits to keep: ${COMMIT_COUNT}"
+          echo "  - Dry run: ${DRY_RUN}"
+
+      - name: "11.04 Clean branch history"
+        run: |
+          BRANCHES="${{ steps.validate.outputs.branches }}"
+          COMMIT_COUNT="${{ steps.validate.outputs.commit_count }}"
+          DRY_RUN="${{ steps.validate.outputs.dry_run }}"
+          
+          # Convert comma-separated branches to array
+          IFS=',' read -ra BRANCH_ARRAY <<< "$BRANCHES"
+          
+          for BRANCH in "${BRANCH_ARRAY[@]}"; do
+            # Trim whitespace
+            BRANCH=$(echo "$BRANCH" | xargs)
+            
+            echo "🔄 Processing branch: $BRANCH"
+            
+            # Check if branch exists on remote
+            if ! git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+              echo "⚠️ Branch '$BRANCH' does not exist on remote, skipping..."
+              continue
+            fi
+            
+            # Fetch the branch
+            git fetch origin "$BRANCH"
+            
+            # Check out the branch
+            git checkout "$BRANCH"
+            git reset --hard "origin/$BRANCH"
+            
+            # Count total commits
+            TOTAL_COMMITS=$(git rev-list --count HEAD)
+            echo "📊 Total commits in $BRANCH: $TOTAL_COMMITS"
+            
+            if [ "$TOTAL_COMMITS" -le "$COMMIT_COUNT" ]; then
+              echo "ℹ️ Branch $BRANCH has $TOTAL_COMMITS commits, which is <= $COMMIT_COUNT. No cleanup needed."
+              continue
+            fi
+            
+            # Get the commit hash that will become the new root
+            NEW_ROOT_COMMIT=$(git rev-parse "HEAD~$((COMMIT_COUNT-1))")
+            echo "📌 New root commit will be: $NEW_ROOT_COMMIT"
+            
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "🔍 DRY RUN: Would clean $BRANCH branch keeping last $COMMIT_COUNT commits"
+              echo "🔍 DRY RUN: Would remove $((TOTAL_COMMITS - COMMIT_COUNT)) commits"
+              echo "🔍 DRY RUN: New root would be: $NEW_ROOT_COMMIT"
+              
+              # Show commits that would be removed
+              echo "🔍 DRY RUN: Commits that would be removed:"
+              git log --oneline "HEAD~$COMMIT_COUNT..HEAD~$TOTAL_COMMITS" 2>/dev/null || echo "  (no commits to remove beyond history)"
+            else
+              echo "🧹 Cleaning $BRANCH branch to keep last $COMMIT_COUNT commits..."
+              
+              # Create orphan branch from the new root commit
+              TEMP_BRANCH="temp-clean-$BRANCH-$(date +%s)"
+              git checkout --orphan "$TEMP_BRANCH" "$NEW_ROOT_COMMIT"
+              
+              # Commit the current state as the new initial commit
+              git commit -m "Clean history: keeping last $COMMIT_COUNT commits
+              
+              Original branch had $TOTAL_COMMITS commits.
+              Removed $((TOTAL_COMMITS - COMMIT_COUNT)) older commits.
+              History cleaned on $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+              
+              # Replay the remaining commits
+              echo "📝 Replaying last $((COMMIT_COUNT-1)) commits..."
+              git cherry-pick "$NEW_ROOT_COMMIT..origin/$BRANCH"
+              
+              # Replace the original branch
+              git branch -M "$TEMP_BRANCH" "$BRANCH"
+              
+              # Force push the cleaned branch
+              echo "📤 Force pushing cleaned $BRANCH branch..."
+              git push --force-with-lease origin "$BRANCH"
+              
+              echo "✅ Successfully cleaned $BRANCH branch"
+              echo "📊 Removed $((TOTAL_COMMITS - COMMIT_COUNT)) commits, kept $COMMIT_COUNT commits"
+            fi
+            
+            echo "---"
+          done
+
+      - name: "11.05 Summary"
+        run: |
+          BRANCHES="${{ steps.validate.outputs.branches }}"
+          COMMIT_COUNT="${{ steps.validate.outputs.commit_count }}"
+          DRY_RUN="${{ steps.validate.outputs.dry_run }}"
+          
+          echo "📋 History cleanup summary:"
+          echo "  - Branches processed: $BRANCHES"
+          echo "  - Commits kept per branch: $COMMIT_COUNT"
+          echo "  - Mode: $([ "$DRY_RUN" = "true" ] && echo "DRY RUN" || echo "EXECUTED")"
+          
+          if [ "$DRY_RUN" = "true" ]; then
+            echo ""
+            echo "⚠️ This was a dry run. No changes were made to the repository."
+            echo "💡 To execute the cleanup, run this workflow again with 'Perform a dry run' unchecked."
+          else
+            echo ""
+            echo "✅ History cleanup completed successfully!"
+            echo "⚠️ Note: This operation modifies git history. All developers should re-clone or reset their local repositories."
+          fi


### PR DESCRIPTION
Add a manually triggerable GitHub workflow to clean up `main` and `release` branch history, keeping the last 50 commits.

---
<a href="https://cursor.com/background-agent?bcId=bc-a19d7495-688f-49bc-9fad-767f9cf23862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a19d7495-688f-49bc-9fad-767f9cf23862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>