### PR TITLE
Investigate and fix include relationship discrepancies

### DIFF
--- a/src/c2puml/core/transformer.py
+++ b/src/c2puml/core/transformer.py
@@ -2167,8 +2167,8 @@ class Transformer:
                 
                 # Process each include in the current file
                 for include_name in current_file.includes:
-                    # Apply include filters only at depth 1 (direct includes from root C file)
-                    if compiled_filters and depth == 1:
+                    # Apply include filters at all depths (not just depth 1)
+                    if compiled_filters:
                         if not any(pattern.search(include_name) for pattern in compiled_filters):
                             self.logger.debug(
                                 "Filtered out include %s at depth %d for %s",


### PR DESCRIPTION
Apply file-specific include filters at all depths to correctly filter transitive includes.

---
<a href="https://cursor.com/background-agent?bcId=bc-83b29977-5f79-433c-bddd-75e3d1d7ea9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83b29977-5f79-433c-bddd-75e3d1d7ea9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>