### PR TITLE
Refactor and unify application tests

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,330 @@
+# C2PUML Test Framework Unification - Todo
+
+## Executive Summary
+
+This document outlines the comprehensive work required to transform the current c2puml test suite (58 test files across unit, feature, and integration categories) into a unified, maintainable, and robust testing framework. The primary focus is on **test-application boundary separation** and **public API testing** to ensure the application remains flexible to internal changes.
+
+## Current State Analysis
+
+### Current Test Structure
+- **58 test files** across 3 categories:
+  - `tests/unit/` (37 files) - Individual component tests
+  - `tests/feature/` (12 files) - Complete workflow tests  
+  - `tests/integration/` (2 files) - End-to-end scenarios
+  - `tests/example/` (1 file) - Example project test
+- **Mixed testing approaches**: Some tests use internal functions, others use public APIs
+- **Inconsistent patterns**: Different test classes use different setup/teardown approaches
+- **Direct internal access**: Many tests directly import and test internal components
+
+### Public API Surface (Target for Testing)
+Based on analysis of the codebase, the public APIs are:
+
+1. **CLI Interface** (`main.py`):
+   ```bash
+   c2puml --config config.json [parse|transform|generate]
+   python3 main.py --config config.json [parse|transform|generate]
+   ```
+
+2. **Package Interface** (`src/c2puml/__init__.py`):
+   ```python
+   from c2puml import Parser, Transformer, Generator
+   ```
+
+3. **Configuration Interface**:
+   - JSON configuration files with standardized schema
+   - Input: C/C++ source files and headers
+   - Output: model.json, transformed_model.json, .puml files
+
+## Work Items
+
+### 1. Unified Testing Framework Design
+
+#### 1.1 Core Testing Framework (`tests/framework/`)
+**Priority: HIGH**
+
+Create a new unified framework with these components:
+
+- **`TestExecutor`**: Runs c2puml through public APIs only
+- **`TestDataFactory`**: Generates test C/C++ projects and configurations
+- **`ResultValidator`**: Validates outputs (model.json, .puml files, logs)
+- **`TestProjectBuilder`**: Builds temporary test projects with complex structures
+
+```python
+# Example structure
+tests/framework/
+├── __init__.py
+├── executor.py      # TestExecutor class
+├── data_factory.py  # TestDataFactory class  
+├── validator.py     # ResultValidator class
+├── builder.py       # TestProjectBuilder class
+└── fixtures.py      # Common test fixtures
+```
+
+#### 1.2 Test Execution Patterns
+**Priority: HIGH**
+
+Standardize how tests execute c2puml:
+
+```python
+class UnifiedTestCase(unittest.TestCase):
+    def setUp(self):
+        self.executor = TestExecutor()
+        self.data_factory = TestDataFactory()
+        self.validator = ResultValidator()
+    
+    def test_feature(self):
+        # 1. Generate test data
+        project = self.data_factory.create_c_project(...)
+        config = self.data_factory.create_config(...)
+        
+        # 2. Execute through public API
+        result = self.executor.run_full_pipeline(project, config)
+        
+        # 3. Validate results
+        self.validator.assert_model_valid(result.model)
+        self.validator.assert_puml_contains(result.puml, expected_elements)
+```
+
+### 2. Public API Testing Strategy
+
+#### 2.1 CLI Interface Testing
+**Priority: HIGH**
+
+All tests should execute c2puml through:
+- Direct CLI calls using `subprocess`
+- Package imports using the public `c2puml` module interface
+
+**Forbidden**: Direct imports of internal modules like:
+- `from c2puml.core.parser import CParser` ❌
+- `from c2puml.core.tokenizer import CTokenizer` ❌
+
+**Allowed**: Public interfaces only:
+- `from c2puml import Parser, Transformer, Generator` ✅
+- CLI execution: `subprocess.run(['python3', 'main.py', '--config', ...])` ✅
+
+#### 2.2 Test Input/Output Validation
+**Priority: HIGH**
+
+Tests should validate:
+- **Input validation**: Configuration files, C/C++ source structure
+- **Output validation**: Generated model.json structure, PlantUML syntax, file organization
+- **Log validation**: Error messages, warning patterns, execution flow
+
+### 3. Test Data Management
+
+#### 3.1 Standardized Test Data Factory
+**Priority: MEDIUM**
+
+Create reusable test data generators:
+
+```python
+class TestDataFactory:
+    def create_simple_c_project(self) -> TestProject:
+        """Creates basic C project with structs, functions, headers"""
+    
+    def create_complex_c_project(self) -> TestProject:
+        """Creates complex project with includes, typedefs, unions"""
+    
+    def create_transformation_test_project(self) -> TestProject:
+        """Creates project designed for transformation testing"""
+    
+    def create_config(self, **overrides) -> ConfigData:
+        """Creates standardized configuration with optional overrides"""
+```
+
+#### 3.2 Test Project Templates
+**Priority: MEDIUM**
+
+Standardized C/C++ project templates for testing:
+- **`simple_project`**: Basic structs, functions, single files
+- **`multi_file_project`**: Multiple C files with cross-references
+- **`complex_includes`**: Deep include hierarchies
+- **`transformation_project`**: Elements designed for rename/remove testing
+- **`error_project`**: Malformed C code for error handling tests
+
+### 4. Result Validation Framework
+
+#### 4.1 Model Validation
+**Priority: HIGH**
+
+Structured validation of generated models:
+
+```python
+class ModelValidator:
+    def assert_struct_exists(self, model: dict, struct_name: str)
+    def assert_function_declared(self, model: dict, func_name: str)
+    def assert_include_relationship(self, model: dict, source: str, target: str)
+    def assert_transformation_applied(self, before: dict, after: dict, transformation: dict)
+```
+
+#### 4.2 PlantUML Validation
+**Priority: HIGH**
+
+Validation of generated PlantUML files:
+
+```python
+class PlantUMLValidator:
+    def assert_class_exists(self, puml_content: str, class_name: str, stereotype: str)
+    def assert_relationship(self, puml_content: str, source: str, target: str, rel_type: str)
+    def assert_formatting_compliant(self, puml_content: str)
+    def assert_no_duplicate_elements(self, puml_content: str)
+```
+
+### 5. Test Organization and Refactoring
+
+#### 5.1 Test Categorization
+**Priority: MEDIUM**
+
+Reorganize 58 test files into clear categories:
+
+```
+tests/
+├── framework/           # New unified testing framework
+├── unit/               # Refactored unit tests (public API only)
+│   ├── test_parsing.py       # CLI parsing functionality
+│   ├── test_transformation.py # Transformation workflows
+│   ├── test_generation.py     # PlantUML generation
+│   └── test_configuration.py  # Configuration handling
+├── feature/            # Refactored feature tests
+│   ├── test_full_workflow.py     # End-to-end workflows
+│   ├── test_include_processing.py # Include depth and filtering
+│   ├── test_transformations.py    # Model transformations
+│   └── test_error_handling.py     # Error scenarios
+├── integration/        # Integration tests
+│   ├── test_real_projects.py     # Tests with realistic C projects
+│   └── test_performance.py       # Performance benchmarks
+└── data/              # Test data and expected outputs
+    ├── projects/      # Test C/C++ projects
+    ├── configs/       # Test configurations
+    └── expected/      # Expected outputs
+```
+
+#### 5.2 Test Naming Conventions
+**Priority: LOW**
+
+Standardize test naming:
+- `test_<functionality>_<scenario>_<expectation>`
+- Example: `test_parsing_complex_project_generates_valid_model`
+- Example: `test_transformation_rename_function_updates_references`
+
+### 6. Boundary Separation and Component Isolation
+
+#### 6.1 Test-Application Boundaries
+**Priority: HIGH**
+
+Ensure clean separation:
+- **Tests only interact with public APIs**
+- **No direct access to internal classes/functions**  
+- **No mocking of internal components**
+- **Tests validate behavior, not implementation**
+
+#### 6.2 Component Boundary Testing
+**Priority: MEDIUM**
+
+Test component integration through public interfaces:
+- Parser → Transformer → Generator pipeline
+- Configuration loading and validation
+- Error propagation and handling
+- File I/O and output organization
+
+### 7. Test Readability and Maintainability
+
+#### 7.1 Standardized Test Patterns
+**Priority: MEDIUM**
+
+Common patterns for all tests:
+
+```python
+class TestFeatureName(UnifiedTestCase):
+    def setUp(self):
+        super().setUp()
+        # Feature-specific setup
+    
+    def test_scenario_name(self):
+        """Clear description of what this test validates"""
+        # Arrange
+        project = self.create_test_project(...)
+        config = self.create_test_config(...)
+        
+        # Act  
+        result = self.execute_c2puml(project, config)
+        
+        # Assert
+        self.validate_expected_output(result, expected_items)
+```
+
+#### 7.2 Documentation Standards
+**Priority: LOW**
+
+- **Clear test descriptions**: Each test explains what it validates
+- **Setup documentation**: Complex test setups are well-documented
+- **Expected behavior**: Tests clearly state expected outcomes
+- **Failure diagnostics**: Useful error messages for test failures
+
+### 8. Implementation Plan
+
+#### Phase 1: Framework Foundation (Week 1-2)
+1. Create `tests/framework/` structure
+2. Implement `TestExecutor` with CLI interface
+3. Implement basic `TestDataFactory`
+4. Implement `ResultValidator` for models and PlantUML
+
+#### Phase 2: Public API Migration (Week 3-4)
+1. Identify tests using internal APIs (audit all 58 files)
+2. Refactor high-priority unit tests to use public APIs
+3. Create conversion utilities for existing test patterns
+
+#### Phase 3: Test Reorganization (Week 5-6)
+1. Reorganize tests into new category structure
+2. Consolidate duplicate test logic
+3. Standardize test naming and documentation
+
+#### Phase 4: Validation and Cleanup (Week 7-8)
+1. Ensure all tests pass with new framework
+2. Performance testing of new test suite
+3. Documentation updates and test coverage analysis
+4. Remove deprecated test utilities
+
+### 9. Success Criteria
+
+#### Technical Criteria
+- **Zero internal API usage**: All tests use only public APIs
+- **100% test pass rate**: All migrated tests pass consistently  
+- **Maintainable boundaries**: Clear separation between test and application code
+- **Consistent patterns**: All tests follow unified structure and naming
+
+#### Quality Criteria
+- **Test readability**: Tests are easy to understand and modify
+- **Failure diagnostics**: Test failures provide clear guidance
+- **Coverage preservation**: No reduction in test coverage during migration
+- **Performance**: Test suite execution time remains reasonable
+
+#### Validation Criteria
+- **Flexible to changes**: Tests continue passing when internal implementation changes
+- **Comprehensive validation**: Tests validate all aspects of public API behavior
+- **Realistic scenarios**: Tests cover real-world usage patterns
+- **Error handling**: Tests validate error conditions and edge cases
+
+### 10. Risk Mitigation
+
+#### Migration Risks
+- **Breaking existing tests**: Gradual migration with parallel test execution
+- **Coverage gaps**: Careful mapping of existing test coverage to new structure
+- **Performance degradation**: Monitoring test execution times during migration
+
+#### Maintenance Risks  
+- **Framework complexity**: Keep framework simple and well-documented
+- **Over-abstraction**: Balance reusability with test clarity
+- **Dependency management**: Minimize external dependencies in test framework
+
+---
+
+## Next Steps
+
+1. **Review and approve** this plan with the development team
+2. **Create framework foundation** in `tests/framework/`
+3. **Start with pilot migration** of 5-10 representative test files
+4. **Iterate and refine** framework based on pilot results
+5. **Execute full migration** following the phase plan
+
+This unified testing approach will ensure that c2puml remains flexible to internal changes while providing comprehensive validation of its public API functionality.


### PR DESCRIPTION
Create `todo.md` to outline a plan for unifying the test framework and enforcing public API testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d05ed21-59ef-4e30-b681-9157f073f1c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d05ed21-59ef-4e30-b681-9157f073f1c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

