### PR TITLE
Reformat test yml files with newlines

### DIFF
--- a/scripts/reformat_tests_yaml_newlines.py
+++ b/scripts/reformat_tests_yaml_newlines.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import sys
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+    from ruamel.yaml.scalarstring import (
+        DoubleQuotedScalarString,
+        SingleQuotedScalarString,
+        LiteralScalarString,
+        FoldedScalarString,
+    )
+except Exception as e:
+    print("Error: ruamel.yaml is required. Install with: pip install ruamel.yaml", file=sys.stderr)
+    raise
+
+
+def transform_scalar(value: Any) -> Any:
+    # Only convert double-quoted scalars that contain the literal backslash-n sequence
+    if isinstance(value, DoubleQuotedScalarString) and "\\n" in value:
+        # Replace the escape sequences with actual newlines and switch style to literal block scalar
+        new_text = value.replace("\\n", "\n")
+        return LiteralScalarString(new_text)
+
+    # Do NOT touch single-quoted scalars; they likely intend literal backslashes
+    if isinstance(value, SingleQuotedScalarString):
+        return value
+
+    # Recurse into collections
+    if isinstance(value, (CommentedMap, dict)):
+        for k in list(value.keys()):
+            value[k] = transform_scalar(value[k])
+        return value
+    if isinstance(value, (CommentedSeq, list, tuple)):
+        for i in range(len(value)):
+            value[i] = transform_scalar(value[i])
+        return value
+
+    return value
+
+
+def process_file(path: Path) -> bool:
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    # Load all YAML documents
+    with path.open("r", encoding="utf-8") as f:
+        docs = list(yaml.load_all(f))
+
+    changed = False
+    new_docs = []
+    for doc in docs:
+        before = str(doc)
+        transformed = transform_scalar(doc)
+        after = str(transformed)
+        if before != after:
+            changed = True
+        new_docs.append(transformed)
+
+    if changed:
+        with path.open("w", encoding="utf-8", newline="\n") as f:
+            yaml.dump_all(new_docs, f)
+    return changed
+
+
+def main(argv: list[str]) -> int:
+    root = Path("/workspace/tests")
+    if not root.exists():
+        print(f"Tests directory not found: {root}", file=sys.stderr)
+        return 1
+
+    yml_files = sorted(root.rglob("*.yml"))
+    if not yml_files:
+        print("No YAML files found under tests/", file=sys.stderr)
+        return 0
+
+    changed_count = 0
+    for yml in yml_files:
+        try:
+            if process_file(yml):
+                changed_count += 1
+                print(f"Reformatted: {yml}")
+        except Exception as e:
+            print(f"Failed to process {yml}: {e}", file=sys.stderr)
+            return 2
+
+    print(f"Done. Files changed: {changed_count} / {len(yml_files)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/reformat_tests_yaml_newlines_plain.py
+++ b/scripts/reformat_tests_yaml_newlines_plain.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+# Pattern to match lines like: key: "..." where the value is a single-line double-quoted scalar
+LINE_PATTERN = re.compile(r'^(?P<indent>\s*)(?P<key>[^:\n]+?):\s*"(?P<value>.*)"\s*$')
+# Replace unescaped \n (not preceded by backslash) with a real newline
+UNESCAPED_NEWLINE = re.compile(r'(?<!\\)\\n')
+
+
+def convert_line_to_block(indent: str, key: str, value: str) -> str | None:
+    # Only proceed if the value contains at least one unescaped \n
+    if not UNESCAPED_NEWLINE.search(value):
+        return None
+
+    # Convert YAML-escaped quotes (\") to normal quotes for block scalar content
+    # Keep escaped backslash-n (\\n) intact for C string literals
+    text = value
+    text = text.replace('\\"', '"')
+    text = UNESCAPED_NEWLINE.sub('\n', text)
+
+    # Emit block scalar with two-space indent for content
+    content_indent = indent + '  '
+    lines = text.split('\n')
+    block_lines = [f"{content_indent}{ln}" if ln != '' else f"{content_indent}" for ln in lines]
+    return f"{indent}{key}: |\n" + "\n".join(block_lines)
+
+
+def process_file(path: Path) -> bool:
+    original = path.read_text(encoding='utf-8')
+    lines = original.splitlines()
+
+    changed_any = False
+    new_lines: list[str] = []
+
+    for line in lines:
+        m = LINE_PATTERN.match(line)
+        if m:
+            repl = convert_line_to_block(m.group('indent'), m.group('key'), m.group('value'))
+            if repl is not None:
+                new_lines.append(repl)
+                changed_any = True
+                continue
+        new_lines.append(line)
+
+    if changed_any:
+        # Ensure final file ends with a newline
+        path.write_text("\n".join(new_lines) + "\n", encoding='utf-8')
+    return changed_any
+
+
+def main() -> int:
+    root = Path('/workspace/tests')
+    files = sorted(root.rglob('*.yml'))
+    changed = 0
+    for f in files:
+        if process_file(f):
+            print(f"Reformatted: {f}")
+            changed += 1
+    print(f"Done. Files changed: {changed} / {len(files)}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/reformat_yaml_newlines_stateful.py
+++ b/scripts/reformat_yaml_newlines_stateful.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+
+def find_quoted_value(lines: List[str], start_line: int, start_col: int) -> Tuple[str, int, int]:
+    """
+    Given lines and a starting position at the opening quote (") of a YAML value,
+    return the full quoted value content (without quotes) and the end position
+    (end_line, end_col) at the closing quote.
+    Handles escaped quotes (\") and spans multiple lines.
+    """
+    buf: List[str] = []
+    line_idx = start_line
+    col_idx = start_col + 1  # skip opening quote
+    escaped = False
+    while line_idx < len(lines):
+        line = lines[line_idx]
+        while col_idx < len(line):
+            ch = line[col_idx]
+            if escaped:
+                buf.append(ch)
+                escaped = False
+            else:
+                if ch == '\\':
+                    # keep the backslash in buffer so we can detect sequences like \\n later
+                    buf.append('\\')
+                    escaped = True
+                elif ch == '"':
+                    # closing quote
+                    return ("".join(buf), line_idx, col_idx)
+                else:
+                    buf.append(ch)
+            col_idx += 1
+        # move to next line (include a real newline to preserve the raw scalar text formatting)
+        buf.append('\n')
+        line_idx += 1
+        col_idx = 0
+    raise ValueError(f"Unterminated quoted string starting at line {start_line+1}:{start_col+1}")
+
+
+def rewrite_to_block_scalar(indent: str, key: str, raw_value: str) -> str | None:
+    # Only rewrite if the raw_value contains literal backslash-n sequence
+    if "\\n" not in raw_value:
+        return None
+
+    # Replace escaped quote sequences with normal quotes for block content
+    text = raw_value.replace('\\"', '"')
+    # Replace literal backslash-n with real newlines
+    text = text.replace('\\n', '\n')
+
+    # Build block scalar with two-space additional indent
+    content_indent = indent + '  '
+    content_lines = text.split('\n')
+    # Ensure we do not add trailing spaces to empty lines
+    body = "\n".join((f"{content_indent}{ln}" if ln != '' else f"{content_indent}") for ln in content_lines)
+    return f"{indent}{key}: |\n{body}"
+
+
+def process_file(path: Path) -> bool:
+    lines = path.read_text(encoding='utf-8').splitlines()
+    i = 0
+    changed = False
+    out_lines: List[str] = []
+
+    while i < len(lines):
+        line = lines[i]
+        # Find a colon that starts a value immediately followed by optional spaces and a double-quote
+        # We also capture indentation and key up to the colon (avoid mapping values with inline maps)
+        # Simple scan for first colon not within quotes
+        in_quote = False
+        esc = False
+        colon_pos = -1
+        for idx, ch in enumerate(line):
+            if in_quote:
+                if esc:
+                    esc = False
+                elif ch == '\\':
+                    esc = True
+                elif ch == '"':
+                    in_quote = False
+            else:
+                if ch == '"':
+                    in_quote = True
+                elif ch == ':':
+                    colon_pos = idx
+                    break
+        if colon_pos == -1:
+            out_lines.append(line)
+            i += 1
+            continue
+
+        # Determine indentation and key
+        before = line[:colon_pos]
+        after = line[colon_pos+1:]
+        indent_len = len(before) - len(before.lstrip(' '))
+        indent = before[:indent_len]
+        key = before[indent_len:]
+        # If value starts with spaces then a double-quote, we can parse it as a quoted scalar
+        j = 0
+        while j < len(after) and after[j] in ' \t':
+            j += 1
+        if j < len(after) and after[j] == '"':
+            # parse quoted value across lines
+            try:
+                raw_value, end_line, end_col = find_quoted_value(lines, i, colon_pos + 1 + j)
+            except ValueError:
+                # Fallback: leave as is
+                out_lines.append(line)
+                i += 1
+                continue
+            replacement = rewrite_to_block_scalar(indent, key.strip(), raw_value)
+            if replacement is None:
+                # No change; emit original lines slice
+                out_lines.append(line)
+                # plus any continuation lines within the quoted scalar untouched
+                # We need to append the full original joined segment
+                k = i + 1
+                while k <= end_line:
+                    out_lines.append(lines[k])
+                    k += 1
+                i = end_line + 1
+                continue
+            # We have a block scalar replacement. Append it and skip original spanned lines.
+            out_lines.append(replacement)
+            changed = True
+            i = end_line + 1
+            # Skip any trailing content on the closing quote line (unlikely in our YAML)
+            continue
+        else:
+            # Not a double-quoted scalar value; copy line and continue
+            out_lines.append(line)
+            i += 1
+
+    if changed:
+        Path(path).write_text("\n".join(out_lines) + "\n", encoding='utf-8')
+    return changed
+
+
+def main() -> int:
+    root = Path('/workspace/tests')
+    files = sorted(root.rglob('*.yml'))
+    changed = 0
+    for f in files:
+        if process_file(f):
+            print(f"Reformatted: {f}")
+            changed += 1
+    print(f"Done. Files changed: {changed} / {len(files)}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/feature/test_201_cli_modes.yml
+++ b/tests/feature/test_201_cli_modes.yml
@@ -21,8 +21,15 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"cli_modes_and_features\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "cli_modes_and_features",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/feature/test_202_include_proc.yml
+++ b/tests/feature/test_202_include_proc.yml
@@ -67,10 +67,19 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"include_processing_all\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 3,\n  \"file_specific\": {\"main.c\": {\"include_depth\": 2}}\n\
-  }\n"
+config.json: |
+  {
+    "project_name": "include_processing_all",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 3,
+    "file_specific": {"main.c": {"include_depth": 2}}
+  \
+    }
+  
 ---
 cli_execution:
   steps:

--- a/tests/feature/test_202_include_proc_basic.yml
+++ b/tests/feature/test_202_include_proc_basic.yml
@@ -5,14 +5,40 @@ test:
   id: '202'
 ---
 source_files:
-  main.c: "#include <stdio.h>\n#include \"utils.h\"\n\nint main() {\n    Point p =\
-    \ {0, 0};\n    return 0;\n}\n"
-  utils.h: "#ifndef UTILS_H\n#define UTILS_H\n\ntypedef struct {\n    int x;\n   \
-    \ int y;\n} Point;\n\n#endif\n"
+  main.c: |
+    #include <stdio.h>
+    #include "utils.h"
+    
+    int main() {
+        Point p =\
+        \ {0, 0};
+        return 0;
+    }
+    
+  utils.h: |
+    #ifndef UTILS_H
+    #define UTILS_H
+    
+    typedef struct {
+        int x;
+       \
+        \ int y;
+    } Point;
+    
+    #endif
+    
 ---
-config.json: "{\n  \"project_name\": \"test_include_processing_basic\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 2\n}\n"
+config.json: |
+  {
+    "project_name": "test_include_processing_basic",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 2
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_202_include_proc_error.yml
+++ b/tests/feature/test_202_include_proc_error.yml
@@ -12,8 +12,15 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"include_processing_errors\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "include_processing_errors",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/feature/test_203_comp_features.yml
+++ b/tests/feature/test_203_comp_features.yml
@@ -51,8 +51,15 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"component_features\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "component_features",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/feature/test_204_errors_invalid_config.yml
+++ b/tests/feature/test_204_errors_invalid_config.yml
@@ -6,8 +6,15 @@ test:
 ---
 source_files: {}
 ---
-config.json: "{\n  \"project_name\": \"test_error_handling\",\n  \"source_folders\"\
-  : [],\n  \"output_dir\": \"output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_error_handling",
+    "source_folders"\
+    : [],
+    "output_dir": "output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_204_errors_invalid_source.yml
+++ b/tests/feature/test_204_errors_invalid_source.yml
@@ -6,9 +6,16 @@ test:
 ---
 source_files: {}
 ---
-config.json: "{\n  \"project_name\": \"test_error_handling\",\n  \"source_folders\"\
-  : [\"/nonexistent/path/that/does/not/exist\"],\n  \"output_dir\": \"output\",\n\
-  \  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_error_handling",
+    "source_folders"\
+    : ["/nonexistent/path/that/does/not/exist"],
+    "output_dir": "output",
+  \
+    \  "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_204_errors_partial.yml
+++ b/tests/feature/test_204_errors_partial.yml
@@ -5,12 +5,21 @@ test:
   id: '204'
 ---
 source_files:
-  test.c: "#include <stdio.h>\n\nint main() {\n    printf(\"Hello, World!\\n\");\n\
-    \    return 0;\n}\n"
+  test.c: |
+    #include <stdio.h>nnint main() {n    printf("Hello, World!
+    ");n
+            return 0;n}n
 ---
-config.json: "{\n  \"project_name\": \"test_partial_failures\",\n  \"source_folders\"\
-  : [\"src\", \"/nonexistent/path\"],\n  \"output_dir\": \"output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "test_partial_failures",
+    "source_folders"\
+    : ["src", "/nonexistent/path"],
+    "output_dir": "output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_205_multi_src.yml
+++ b/tests/feature/test_205_multi_src.yml
@@ -5,11 +5,34 @@ test:
   id: '205'
 ---
 source_files:
-  src1/main.c: "#include \"utils.h\"\n\nstruct Person {\n    char name[50];\n    int\
-    \ age;\n};\n\nint main() {\n    struct Person p = {\"John\", 30};\n    return\
-    \ 0;\n}\n"
-  src1/utils.h: "#ifndef UTILS_H\n#define UTILS_H\n\ntypedef struct {\n    int x,\
-    \ y;\n} Point;\n\nvoid print_point(Point p);\n\n#endif\n"
+  src1/main.c: |
+    #include "utils.h"
+    
+    struct Person {
+        char name[50];
+        int\
+        \ age;
+    };
+    
+    int main() {
+        struct Person p = {"John", 30};
+        return\
+        \ 0;
+    }
+    
+  src1/utils.h: |
+    #ifndef UTILS_H
+    #define UTILS_H
+    
+    typedef struct {
+        int x,\
+        \ y;
+    } Point;
+    
+    void print_point(Point p);
+    
+    #endif
+    
   src2/app.c: '#include "types.h"
 
 
@@ -19,16 +42,56 @@ source_files:
     void process_color(enum Color c) {}
 
     '
-  src2/types.h: "#ifndef TYPES_H\n#define TYPES_H\n\ntypedef unsigned int uint32_t;\n\
-    typedef struct {\n    uint32_t id;\n    char name[100];\n} Item;\n\n#endif\n"
-  src3/complex.c: "#include \"data.h\"\n\nunion Data { int i; float f; char str[20];\
-    \ };\n\nstruct Container {\n    union Data data;\n    int type;\n};\n"
-  src3/data.h: "#ifndef DATA_H\n#define DATA_H\n\n#define MAX_SIZE 100\n\ntypedef\
-    \ struct {\n    int values[MAX_SIZE];\n    int count;\n} Array;\n\n#endif\n"
+  src2/types.h: |
+    #ifndef TYPES_H
+    #define TYPES_H
+    
+    typedef unsigned int uint32_t;
+    \
+        typedef struct {
+        uint32_t id;
+        char name[100];
+    } Item;
+    
+    #endif
+    
+  src3/complex.c: |
+    #include "data.h"
+    
+    union Data { int i; float f; char str[20];\
+        \ };
+    
+    struct Container {
+        union Data data;
+        int type;
+    };
+    
+  src3/data.h: |
+    #ifndef DATA_H
+    #define DATA_H
+    
+    #define MAX_SIZE 100
+    
+    typedef\
+        \ struct {
+        int values[MAX_SIZE];
+        int count;
+    } Array;
+    
+    #endif
+    
 ---
-config.json: "{\n  \"project_name\": \"multi_source_test\",\n  \"source_folders\"\
-  : [\"./src/src1\", \"./src/src2\", \"./src/src3\"],\n  \"output_dir\": \"./output\"\
-  ,\n  \"recursive_search\": true,\n  \"include_depth\": 1\n}\n"
+config.json: |
+  {
+    "project_name": "multi_source_test",
+    "source_folders"\
+    : ["./src/src1", "./src/src2", "./src/src3"],
+    "output_dir": "./output"\
+    ,
+    "recursive_search": true,
+    "include_depth": 1
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_207_crypto_filter_pattern.yml
+++ b/tests/feature/test_207_crypto_filter_pattern.yml
@@ -5,19 +5,44 @@ test:
   id: '207'
 ---
 source_files:
-  crypto.c: "void encrypt_data() {\n    // Encryption logic\n}\n\nvoid decrypt_data()\
-    \ {\n    // Decryption logic  \n}\n"
-  main.c: "#include \"crypto.h\"\n\nint main() {\n    encrypt_data();\n    return\
-    \ 0;\n}\n"
+  crypto.c: |
+    void encrypt_data() {
+        // Encryption logic
+    }
+    
+    void decrypt_data()\
+        \ {
+        // Decryption logic  
+    }
+    
+  main.c: |
+    #include "crypto.h"
+    
+    int main() {
+        encrypt_data();
+        return\
+        \ 0;
+    }
+    
   crypto.h: 'void encrypt_data();
 
     void decrypt_data();
 
     '
 ---
-config.json: "{\n  \"project_name\": \"crypto_filter_test\",\n  \"source_folders\"\
-  : [\".\"],\n  \"recursive_search\": true,\n  \"output_dir\": \"./output\",\n  \"\
-  filters\": {\n    \"remove_files\": [\"crypto\\\\..*\"]\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "crypto_filter_test",
+    "source_folders"\
+    : ["."],
+    "recursive_search": true,
+    "output_dir": "./output",
+    "\
+    filters": {
+      "remove_files": ["crypto\\\\..*"]
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_208_crypto_filter_usecase.yml
+++ b/tests/feature/test_208_crypto_filter_usecase.yml
@@ -5,13 +5,34 @@ test:
   id: '208'
 ---
 source_files:
-  main.c: "int main() {\n    return 0;\n}\n"
-  crypto.c: "void aes_encrypt() {\n    // AES encryption\n}\nvoid rsa_encrypt() {\n\
-    \    // RSA encryption\n}\n"
+  main.c: |
+    int main() {
+        return 0;
+    }
+    
+  crypto.c: |
+    void aes_encrypt() {
+        // AES encryption
+    }
+    void rsa_encrypt() {
+    \
+        \    // RSA encryption
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"crypto_usecase_test\",\n  \"source_folders\"\
-  : [\".\"],\n  \"recursive_search\": true,\n  \"output_dir\": \"./output\",\n  \"\
-  filters\": {\n    \"remove_files\": [\"crypto\\\\..*\"]\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "crypto_usecase_test",
+    "source_folders"\
+    : ["."],
+    "recursive_search": true,
+    "output_dir": "./output",
+    "\
+    filters": {
+      "remove_files": ["crypto\\\\..*"]
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/feature/test_209_integration_cli.yml
+++ b/tests/feature/test_209_integration_cli.yml
@@ -5,17 +5,47 @@ test:
   id: '209'
 ---
 source_files:
-  main.c: "#include <stdio.h>\n#include \"config.h\"\n\n#define MAX_SIZE 100\n\ntypedef\
-    \ struct Person {\n    char name[50];\n    int age;\n} Person;\n\nenum Status\
-    \ {\n    OK,\n    ERROR\n};\n\nint global_var = 42;\n\nint main() {\n    printf(\"\
-    Hello, World!\\n\");\n    return 0;\n}\n\nvoid process_data(void* data) { }\n"
-  config.h: "#ifndef CONFIG_H\n#define CONFIG_H\n\n#define CONFIG_VERSION \"1.0.0\"\
-    \n\ntypedef struct {\n    int id;\n    char name[100];\n} User;\n\nenum Color\
-    \ {\n    RED,\n    GREEN,\n    BLUE\n};\n\nvoid init_config(void);\n\n#endif\n"
+  main.c: |
+    #include <stdio.h>n#include "config.h"nn#define MAX_SIZE 100nntypedef
+         struct Person {n    char name[50];n    int age;n} Person;nnenum Status
+         {n    OK,n    ERRORn};nnint global_var = 42;nnint main() {n    printf("
+        Hello, World!
+    ");n    return 0;n}nnvoid process_data(void* data) { }n
+  config.h: |
+    #ifndef CONFIG_H
+    #define CONFIG_H
+    
+    #define CONFIG_VERSION "1.0.0"\
+        
+    
+    typedef struct {
+        int id;
+        char name[100];
+    } User;
+    
+    enum Color\
+        \ {
+        RED,
+        GREEN,
+        BLUE
+    };
+    
+    void init_config(void);
+    
+    #endif
+    
 ---
-config.json: "{\n  \"project_name\": \"integration_cli_project\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 2\n}\n"
+config.json: |
+  {
+    "project_name": "integration_cli_project",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 2
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/integration/test_301_integration_complete.yml
+++ b/tests/integration/test_301_integration_complete.yml
@@ -6,54 +6,238 @@ test:
   id: '301'
 ---
 source_files:
-  src/main.c: "#include \"game/game.h\"\n#include \"platform/platform.h\"\n\nint main(int\
-    \ argc, char** argv) {\n    Platform platform;\n    Game game;\n\n    if (!platform_init(&platform))\
-    \ {\n        return -1;\n    }\n\n    if (!game_init(&game, &platform)) {\n  \
-    \      platform_shutdown(&platform);\n        return -1;\n    }\n\n    while (platform_is_running(&platform))\
-    \ {\n        platform_update(&platform);\n        game_update(&game, platform_get_delta_time(&platform));\n\
-    \        game_render(&game);\n    }\n\n    game_shutdown(&game);\n    platform_shutdown(&platform);\n\
-    \n    return 0;\n}\n"
-  src/game/game.h: "#ifndef GAME_H\n#define GAME_H\n\n#include \"../platform/platform.h\"\
-    \n#include \"entities/player.h\"\n#include \"world/level.h\"\n#include \"rendering/renderer.h\"\
-    \n\ntypedef struct {\n    Platform* platform;\n    Player player;\n    Level current_level;\n\
-    \    Renderer renderer;\n    double total_time;\n} Game;\n\nint game_init(Game*\
-    \ game, Platform* platform);\nvoid game_update(Game* game, double delta_time);\n\
-    void game_render(Game* game);\nvoid game_shutdown(Game* game);\n\n#endif\n"
-  src/game/entities/player.h: "#ifndef PLAYER_H\n#define PLAYER_H\n\n#include \"../../math/vector.h\"\
-    \n#include \"../../physics/rigidbody.h\"\n\ntypedef struct {\n    Vector3 position;\n\
-    \    Vector3 velocity;\n    RigidBody physics;\n    float health;\n    int score;\n\
-    } Player;\n\n#endif\n"
-  src/game/world/level.h: "#ifndef LEVEL_H\n#define LEVEL_H\n\n#include \"../entities/player.h\"\
-    \n#include \"../../graphics/mesh.h\"\n\ntypedef struct {\n    Mesh* geometry;\n\
-    \    Player* players;\n    int player_count;\n    char* name;\n} Level;\n\n#endif\n"
-  src/game/rendering/renderer.h: "#ifndef RENDERER_H\n#define RENDERER_H\n\n#include\
-    \ \"../../graphics/context.h\"\n#include \"../../graphics/shader.h\"\n\ntypedef\
-    \ struct {\n    GraphicsContext context;\n    Shader* active_shader;\n    int\
-    \ frame_count;\n} Renderer;\n\n#endif\n"
-  src/platform/platform.h: "#ifndef PLATFORM_H\n#define PLATFORM_H\n\ntypedef struct\
-    \ {\n    void* window_handle;\n    int window_width;\n    int window_height;\n\
-    \    double last_frame_time;\n} Platform;\n\nint platform_init(Platform* platform);\n\
-    void platform_update(Platform* platform);\nint platform_is_running(Platform* platform);\n\
-    double platform_get_delta_time(Platform* platform);\nvoid platform_shutdown(Platform*\
-    \ platform);\n\n#endif\n"
-  src/math/vector.h: "#ifndef VECTOR_H\n#define VECTOR_H\n\ntypedef struct {\n   \
-    \ float x, y, z;\n} Vector3;\n\nVector3 vector_add(Vector3 a, Vector3 b);\nVector3\
-    \ vector_scale(Vector3 v, float scalar);\n\n#endif\n"
-  src/physics/rigidbody.h: "#ifndef RIGIDBODY_H\n#define RIGIDBODY_H\n\n#include \"\
-    ../math/vector.h\"\n\ntypedef struct {\n    Vector3 position;\n    Vector3 velocity;\n\
-    \    Vector3 acceleration;\n    float mass;\n} RigidBody;\n\n#endif\n"
-  src/graphics/context.h: "#ifndef CONTEXT_H\n#define CONTEXT_H\n\ntypedef struct\
-    \ {\n    void* api_context;\n    int api_version;\n} GraphicsContext;\n\n#endif\n"
-  src/graphics/shader.h: "#ifndef SHADER_H\n#define SHADER_H\n\ntypedef struct {\n\
-    \    unsigned int program_id;\n    char* source_code;\n} Shader;\n\n#endif\n"
-  src/graphics/mesh.h: "#ifndef MESH_H\n#define MESH_H\n\ntypedef struct {\n    float*\
-    \ vertices;\n    unsigned int* indices;\n    int vertex_count;\n    int index_count;\n\
-    } Mesh;\n\n#endif\n"
+  src/main.c: |
+    #include "game/game.h"
+    #include "platform/platform.h"
+    
+    int main(int\
+        \ argc, char** argv) {
+        Platform platform;
+        Game game;
+    
+        if (!platform_init(&platform))\
+        \ {
+            return -1;
+        }
+    
+        if (!game_init(&game, &platform)) {
+      \
+        \      platform_shutdown(&platform);
+            return -1;
+        }
+    
+        while (platform_is_running(&platform))\
+        \ {
+            platform_update(&platform);
+            game_update(&game, platform_get_delta_time(&platform));
+    \
+        \        game_render(&game);
+        }
+    
+        game_shutdown(&game);
+        platform_shutdown(&platform);
+    \
+        
+        return 0;
+    }
+    
+  src/game/game.h: |
+    #ifndef GAME_H
+    #define GAME_H
+    
+    #include "../platform/platform.h"\
+        
+    #include "entities/player.h"
+    #include "world/level.h"
+    #include "rendering/renderer.h"\
+        
+    
+    typedef struct {
+        Platform* platform;
+        Player player;
+        Level current_level;
+    \
+        \    Renderer renderer;
+        double total_time;
+    } Game;
+    
+    int game_init(Game*\
+        \ game, Platform* platform);
+    void game_update(Game* game, double delta_time);
+    \
+        void game_render(Game* game);
+    void game_shutdown(Game* game);
+    
+    #endif
+    
+  src/game/entities/player.h: |
+    #ifndef PLAYER_H
+    #define PLAYER_H
+    
+    #include "../../math/vector.h"\
+        
+    #include "../../physics/rigidbody.h"
+    
+    typedef struct {
+        Vector3 position;
+    \
+        \    Vector3 velocity;
+        RigidBody physics;
+        float health;
+        int score;
+    \
+        } Player;
+    
+    #endif
+    
+  src/game/world/level.h: |
+    #ifndef LEVEL_H
+    #define LEVEL_H
+    
+    #include "../entities/player.h"\
+        
+    #include "../../graphics/mesh.h"
+    
+    typedef struct {
+        Mesh* geometry;
+    \
+        \    Player* players;
+        int player_count;
+        char* name;
+    } Level;
+    
+    #endif
+    
+  src/game/rendering/renderer.h: |
+    #ifndef RENDERER_H
+    #define RENDERER_H
+    
+    #include\
+        \ "../../graphics/context.h"
+    #include "../../graphics/shader.h"
+    
+    typedef\
+        \ struct {
+        GraphicsContext context;
+        Shader* active_shader;
+        int\
+        \ frame_count;
+    } Renderer;
+    
+    #endif
+    
+  src/platform/platform.h: |
+    #ifndef PLATFORM_H
+    #define PLATFORM_H
+    
+    typedef struct\
+        \ {
+        void* window_handle;
+        int window_width;
+        int window_height;
+    \
+        \    double last_frame_time;
+    } Platform;
+    
+    int platform_init(Platform* platform);
+    \
+        void platform_update(Platform* platform);
+    int platform_is_running(Platform* platform);
+    \
+        double platform_get_delta_time(Platform* platform);
+    void platform_shutdown(Platform*\
+        \ platform);
+    
+    #endif
+    
+  src/math/vector.h: |
+    #ifndef VECTOR_H
+    #define VECTOR_H
+    
+    typedef struct {
+       \
+        \ float x, y, z;
+    } Vector3;
+    
+    Vector3 vector_add(Vector3 a, Vector3 b);
+    Vector3\
+        \ vector_scale(Vector3 v, float scalar);
+    
+    #endif
+    
+  src/physics/rigidbody.h: |
+    #ifndef RIGIDBODY_H
+    #define RIGIDBODY_H
+    
+    #include "\
+        ../math/vector.h"
+    
+    typedef struct {
+        Vector3 position;
+        Vector3 velocity;
+    \
+        \    Vector3 acceleration;
+        float mass;
+    } RigidBody;
+    
+    #endif
+    
+  src/graphics/context.h: |
+    #ifndef CONTEXT_H
+    #define CONTEXT_H
+    
+    typedef struct\
+        \ {
+        void* api_context;
+        int api_version;
+    } GraphicsContext;
+    
+    #endif
+    
+  src/graphics/shader.h: |
+    #ifndef SHADER_H
+    #define SHADER_H
+    
+    typedef struct {
+    \
+        \    unsigned int program_id;
+        char* source_code;
+    } Shader;
+    
+    #endif
+    
+  src/graphics/mesh.h: |
+    #ifndef MESH_H
+    #define MESH_H
+    
+    typedef struct {
+        float*\
+        \ vertices;
+        unsigned int* indices;
+        int vertex_count;
+        int index_count;
+    \
+        } Mesh;
+    
+    #endif
+    
 ---
-config.json: "{\n  \"project_name\": \"complete_system_integration_test\",\n  \"source_folders\"\
-  : [\"src\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n \
-  \ \"include_depth\": 5,\n  \"file_filters\": {\n    \"include\": [\"*.c\", \"*.h\"\
-  ],\n    \"exclude\": []\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "complete_system_integration_test",
+    "source_folders"\
+    : ["src"],
+    "output_dir": "./output",
+    "recursive_search": true,
+   \
+    \ "include_depth": 5,
+    "file_filters": {
+      "include": ["*.c", "*.h"\
+    ],
+      "exclude": []
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/integration/test_301_integration_rel_fmt.yml
+++ b/tests/integration/test_301_integration_rel_fmt.yml
@@ -34,8 +34,15 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"integration_rel_format\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "integration_rel_format",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_101_gen_basic.yml
+++ b/tests/unit/test_101_gen_basic.yml
@@ -6,19 +6,82 @@ test:
   id: '101'
 ---
 source_files:
-  main.c: "#include <stdio.h>\n#include <stdlib.h>\n#include \"local.h\"\n\n#define\
-    \ MAX_SIZE 100\n#define DEBUG_MODE 1\n#define VERSION \"1.0\"\n\ntypedef int Integer;\n\
-    typedef char* String;\ntypedef void (*Callback)(int);\n\nstruct Person {\n   \
-    \ char* name;\n    int age;\n    float height;\n};\n\nstruct Config {\n    int\
-    \ max_users;\n    int timeout;\n};\n\nenum Status {\n    OK,\n    ERROR,\n   \
-    \ PENDING\n};\n\nenum Color {\n    RED,\n    GREEN,\n    BLUE\n};\n\nunion Data\
-    \ {\n    int integer_value;\n    float float_value;\n    char* string_value;\n\
-    };\n\nint global_var = 42;\nchar* global_string = \"test\";\n\nint main() {\n\
-    \    return 0;\n}\n\nvoid process_data(void* data) {\n    // Process data\n}\n\
-    \nfloat calculate(float a, float b) {\n    return a + b;\n}\n"
+  main.c: |
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include "local.h"
+    
+    #define\
+        \ MAX_SIZE 100
+    #define DEBUG_MODE 1
+    #define VERSION "1.0"
+    
+    typedef int Integer;
+    \
+        typedef char* String;
+    typedef void (*Callback)(int);
+    
+    struct Person {
+       \
+        \ char* name;
+        int age;
+        float height;
+    };
+    
+    struct Config {
+        int\
+        \ max_users;
+        int timeout;
+    };
+    
+    enum Status {
+        OK,
+        ERROR,
+       \
+        \ PENDING
+    };
+    
+    enum Color {
+        RED,
+        GREEN,
+        BLUE
+    };
+    
+    union Data\
+        \ {
+        int integer_value;
+        float float_value;
+        char* string_value;
+    \
+        };
+    
+    int global_var = 42;
+    char* global_string = "test";
+    
+    int main() {
+    \
+        \    return 0;
+    }
+    
+    void process_data(void* data) {
+        // Process data
+    }
+    \
+        
+    float calculate(float a, float b) {
+        return a + b;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"test_generator_basic_plantuml\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_generator_basic_plantuml",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_102_trans_basic.yml
+++ b/tests/unit/test_102_trans_basic.yml
@@ -5,14 +5,46 @@ test:
   id: '102'
 ---
 source_files:
-  sample.c: "#include <stdio.h>\n\nstruct MyStruct {\n    int value;\n    char name[50];\n\
-    };\n\nenum Status {\n    ACTIVE,\n    INACTIVE\n};\n\nvoid process_data() {\n\
-    \    printf(\"Processing data\");\n}\n\nint global_counter;\n"
+  sample.c: |
+    #include <stdio.h>
+    
+    struct MyStruct {
+        int value;
+        char name[50];
+    \
+        };
+    
+    enum Status {
+        ACTIVE,
+        INACTIVE
+    };
+    
+    void process_data() {
+    \
+        \    printf("Processing data");
+    }
+    
+    int global_counter;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_transformer_basic\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  transformations\": {\n    \"rename\": {\n      \"functions\": {\n        \"process_data\"\
-  : \"handle_data\"\n      }\n    }\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "test_transformer_basic",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    transformations": {
+      "rename": {
+        "functions": {
+          "process_data"\
+    : "handle_data"
+        }
+      }
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_103_abs_path_consistency.yml
+++ b/tests/unit/test_103_abs_path_consistency.yml
@@ -5,22 +5,71 @@ test:
     regardless of path style
 ---
 source_files:
-  shared/config.h: "#ifndef CONFIG_H\n#define CONFIG_H\n\n#define MAX_BUFFER_SIZE\
-    \ 1024\n#define DEFAULT_TIMEOUT 30\n\ntypedef struct {\n    int port;\n    char\
-    \ host[256];\n    int timeout;\n} config_t;\n\nextern config_t global_config;\n\
-    \nvoid config_load(const char* filename);\nvoid config_save(const char* filename);\n\
-    \n#endif\n"
-  core/network.c: "#include \"../shared/config.h\"\n\nconfig_t global_config = {8080,\
-    \ \"localhost\", DEFAULT_TIMEOUT};\n\nvoid network_connect(void) {\n    // Connect\
-    \ using global_config\n    config_load(\"network.conf\");\n}\n\nvoid network_disconnect(void)\
-    \ {\n    config_save(\"network.conf\");\n}\n"
-  main.c: "#include \"shared/config.h\"\n#include \"core/network.c\"  // Direct include\
-    \ for testing path consistency\n\nint main() {\n    config_load(\"main.conf\"\
-    );\n    network_connect();\n    network_disconnect();\n    return 0;\n}\n"
+  shared/config.h: |
+    #ifndef CONFIG_H
+    #define CONFIG_H
+    
+    #define MAX_BUFFER_SIZE\
+        \ 1024
+    #define DEFAULT_TIMEOUT 30
+    
+    typedef struct {
+        int port;
+        char\
+        \ host[256];
+        int timeout;
+    } config_t;
+    
+    extern config_t global_config;
+    \
+        
+    void config_load(const char* filename);
+    void config_save(const char* filename);
+    \
+        
+    #endif
+    
+  core/network.c: |
+    #include "../shared/config.h"
+    
+    config_t global_config = {8080,\
+        \ "localhost", DEFAULT_TIMEOUT};
+    
+    void network_connect(void) {
+        // Connect\
+        \ using global_config
+        config_load("network.conf");
+    }
+    
+    void network_disconnect(void)\
+        \ {
+        config_save("network.conf");
+    }
+    
+  main.c: |
+    #include "shared/config.h"
+    #include "core/network.c"  // Direct include\
+        \ for testing path consistency
+    
+    int main() {
+        config_load("main.conf"\
+        );
+        network_connect();
+        network_disconnect();
+        return 0;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"absolute_vs_relative_path_consistency\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "absolute_vs_relative_path_consistency",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_103_abs_path_include_tree.yml
+++ b/tests/unit/test_103_abs_path_include_tree.yml
@@ -6,10 +6,26 @@ test:
   id: '103'
 ---
 source_files:
-  include/types.h: "#ifndef TYPES_H\n#define TYPES_H\ntypedef struct {\n    float\
-    \ x, y, z;\n} vector3_t;\n#endif\n"
-  utils.h: "#ifndef UTILS_H\n#define UTILS_H\ntypedef struct {\n    int id;\n    char\
-    \ name[32];\n} util_data_t;\nvoid init_utils(void);\n#endif\n"
+  include/types.h: |
+    #ifndef TYPES_H
+    #define TYPES_H
+    typedef struct {
+        float\
+        \ x, y, z;
+    } vector3_t;
+    #endif
+    
+  utils.h: |
+    #ifndef UTILS_H
+    #define UTILS_H
+    typedef struct {
+        int id;
+        char\
+        \ name[32];
+    } util_data_t;
+    void init_utils(void);
+    #endif
+    
   geometry.c: '#include "include/types.h"
 
     vector3_t normalize(vector3_t v) { return v; }
@@ -53,8 +69,15 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"path_resolution_and_include_tree\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "path_resolution_and_include_tree",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:
@@ -109,32 +132,50 @@ assertions:
     syntax_valid: true
 ---
 source_files_generate_only:
-  model.json: "{\n  \"project_name\": \"test_project\",\n  \"source_folder\": \"/test\"\
-    ,\n  \"files\": {\n    \"main.c\": {\"file_path\": \"main.c\", \"name\": \"main.c\"\
-    , \"includes\": [\"app.h\"], \"macros\": [], \"enums\": {}, \"structs\": {}, \"\
-    unions\": {}, \"aliases\": {}, \"functions\": [{\"name\": \"main\", \"return_type\"\
-    : \"int\", \"is_declaration\": false, \"parameters\": []}], \"globals\": []},\n\
-    \    \"app.h\": {\"file_path\": \"app.h\", \"name\": \"app.h\", \"includes\":\
-    \ [\"utils.h\", \"config.h\"], \"macros\": [], \"enums\": {}, \"structs\": {},\
-    \ \"unions\": {}, \"aliases\": {}, \"functions\": [{\"name\": \"app_init\", \"\
-    return_type\": \"void\", \"is_declaration\": true, \"parameters\": []}], \"globals\"\
-    : []},\n    \"utils.h\": {\"file_path\": \"utils.h\", \"name\": \"utils.h\", \"\
-    includes\": [\"types.h\"], \"macros\": [], \"enums\": {}, \"structs\": {}, \"\
-    unions\": {}, \"aliases\": {}, \"functions\": [{\"name\": \"utility_function\"\
-    , \"return_type\": \"void\", \"is_declaration\": true, \"parameters\": []}], \"\
-    globals\": []},\n    \"config.h\": {\"file_path\": \"config.h\", \"name\": \"\
-    config.h\", \"includes\": [], \"macros\": [], \"enums\": {}, \"structs\": {},\
-    \ \"unions\": {}, \"aliases\": {}, \"functions\": [], \"globals\": [{\"name\"\
-    : \"CONFIG_VALUE\", \"type\": \"extern int\"}]},\n    \"types.h\": {\"file_path\"\
-    : \"types.h\", \"name\": \"types.h\", \"includes\": [], \"macros\": [], \"enums\"\
-    : {}, \"structs\": {\"Point\": {\"name\": \"Point\", \"fields\": [{\"name\": \"\
-    x\", \"type\": \"int\"}, {\"name\": \"y\", \"type\": \"int\"}]}}, \"unions\":\
-    \ {}, \"aliases\": {}, \"functions\": [], \"globals\": []}\n  },\n  \"include_relations\"\
-    : [\n    {\"source_file\": \"main.c\", \"included_file\": \"app.h\", \"depth\"\
-    : 1},\n    {\"source_file\": \"app.h\", \"included_file\": \"utils.h\", \"depth\"\
-    : 1},\n    {\"source_file\": \"app.h\", \"included_file\": \"config.h\", \"depth\"\
-    : 1},\n    {\"source_file\": \"utils.h\", \"included_file\": \"types.h\", \"depth\"\
-    : 1}\n  ]\n}\n"
+  model.json: |
+    {
+      "project_name": "test_project",
+      "source_folder": "/test"\
+        ,
+      "files": {
+        "main.c": {"file_path": "main.c", "name": "main.c"\
+        , "includes": ["app.h"], "macros": [], "enums": {}, "structs": {}, "\
+        unions": {}, "aliases": {}, "functions": [{"name": "main", "return_type"\
+        : "int", "is_declaration": false, "parameters": []}], "globals": []},
+    \
+        \    "app.h": {"file_path": "app.h", "name": "app.h", "includes":\
+        \ ["utils.h", "config.h"], "macros": [], "enums": {}, "structs": {},\
+        \ "unions": {}, "aliases": {}, "functions": [{"name": "app_init", "\
+        return_type": "void", "is_declaration": true, "parameters": []}], "globals"\
+        : []},
+        "utils.h": {"file_path": "utils.h", "name": "utils.h", "\
+        includes": ["types.h"], "macros": [], "enums": {}, "structs": {}, "\
+        unions": {}, "aliases": {}, "functions": [{"name": "utility_function"\
+        , "return_type": "void", "is_declaration": true, "parameters": []}], "\
+        globals": []},
+        "config.h": {"file_path": "config.h", "name": "\
+        config.h", "includes": [], "macros": [], "enums": {}, "structs": {},\
+        \ "unions": {}, "aliases": {}, "functions": [], "globals": [{"name"\
+        : "CONFIG_VALUE", "type": "extern int"}]},
+        "types.h": {"file_path"\
+        : "types.h", "name": "types.h", "includes": [], "macros": [], "enums"\
+        : {}, "structs": {"Point": {"name": "Point", "fields": [{"name": "\
+        x", "type": "int"}, {"name": "y", "type": "int"}]}}, "unions":\
+        \ {}, "aliases": {}, "functions": [], "globals": []}
+      },
+      "include_relations"\
+        : [
+        {"source_file": "main.c", "included_file": "app.h", "depth"\
+        : 1},
+        {"source_file": "app.h", "included_file": "utils.h", "depth"\
+        : 1},
+        {"source_file": "app.h", "included_file": "config.h", "depth"\
+        : 1},
+        {"source_file": "utils.h", "included_file": "types.h", "depth"\
+        : 1}
+      ]
+    }
+    
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_103_abs_path_mixed.yml
+++ b/tests/unit/test_103_abs_path_mixed.yml
@@ -5,17 +5,61 @@ test:
     and backward slashes
 ---
 source_files:
-  common/base.h: "#ifndef BASE_H\n#define BASE_H\n\ntypedef struct {\n    int base_id;\n\
-    \    char base_name[64];\n} base_t;\n\nvoid base_init(base_t* b);\n\n#endif\n"
-  modules/graphics.h: "#ifndef GRAPHICS_H\n#define GRAPHICS_H\n\n#include \"../common/base.h\"\
-    \n\ntypedef struct {\n    base_t base;\n    int width;\n    int height;\n} graphics_t;\n\
-    \nvoid graphics_render(graphics_t* g);\n\n#endif\n"
-  app.c: "#include \"common/base.h\"\n#include \"modules/graphics.h\"\n\nint main()\
-    \ {\n    graphics_t gfx;\n    base_init(&gfx.base);\n    graphics_render(&gfx);\n\
-    \    return 0;\n}\n"
+  common/base.h: |
+    #ifndef BASE_H
+    #define BASE_H
+    
+    typedef struct {
+        int base_id;
+    \
+        \    char base_name[64];
+    } base_t;
+    
+    void base_init(base_t* b);
+    
+    #endif
+    
+  modules/graphics.h: |
+    #ifndef GRAPHICS_H
+    #define GRAPHICS_H
+    
+    #include "../common/base.h"\
+        
+    
+    typedef struct {
+        base_t base;
+        int width;
+        int height;
+    } graphics_t;
+    \
+        
+    void graphics_render(graphics_t* g);
+    
+    #endif
+    
+  app.c: |
+    #include "common/base.h"
+    #include "modules/graphics.h"
+    
+    int main()\
+        \ {
+        graphics_t gfx;
+        base_init(&gfx.base);
+        graphics_render(&gfx);
+    \
+        \    return 0;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"mixed_path_styles_handling\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "mixed_path_styles_handling",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_103_abs_path_relative.yml
+++ b/tests/unit/test_103_abs_path_relative.yml
@@ -5,14 +5,41 @@ test:
     without absolute path bugs
 ---
 source_files:
-  utils.h: "#ifndef UTILS_H\n#define UTILS_H\n\ntypedef struct {\n    int id;\n  \
-    \  char name[32];\n} util_data_t;\n\nvoid init_utils(void);\n\n#endif\n"
-  main.c: "#include \"utils.h\"\n\nint main() {\n    util_data_t data;\n    init_utils();\n\
-    \    return 0;\n}\n"
+  utils.h: |
+    #ifndef UTILS_H
+    #define UTILS_H
+    
+    typedef struct {
+        int id;
+      \
+        \  char name[32];
+    } util_data_t;
+    
+    void init_utils(void);
+    
+    #endif
+    
+  main.c: |
+    #include "utils.h"
+    
+    int main() {
+        util_data_t data;
+        init_utils();
+    \
+        \    return 0;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"relative_path_handling_in_include_tree\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "relative_path_handling_in_include_tree",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_103_abs_path_subdir.yml
+++ b/tests/unit/test_103_abs_path_subdir.yml
@@ -5,14 +5,37 @@ test:
     handling
 ---
 source_files:
-  include/types.h: "#ifndef TYPES_H\n#define TYPES_H\n\ntypedef struct {\n    float\
-    \ x, y, z;\n} vector3_t;\n\n#endif\n"
-  geometry.c: "#include \"include/types.h\"\n\nvector3_t normalize(vector3_t v) {\n\
-    \    // Implementation here\n    return v;\n}\n"
+  include/types.h: |
+    #ifndef TYPES_H
+    #define TYPES_H
+    
+    typedef struct {
+        float\
+        \ x, y, z;
+    } vector3_t;
+    
+    #endif
+    
+  geometry.c: |
+    #include "include/types.h"
+    
+    vector3_t normalize(vector3_t v) {
+    \
+        \    // Implementation here
+        return v;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"subdirectory_includes_path_resolution\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "subdirectory_includes_path_resolution",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_104_anon_proc.yml
+++ b/tests/unit/test_104_anon_proc.yml
@@ -6,32 +6,116 @@ test:
   id: '104'
 ---
 source_files:
-  anonymous_test.c: "// Test multi-level nested anonymous structures\ntypedef struct\
-    \ {\n    int level1_id;\n    struct {                        \n        int level2_id;\n\
-    \        union {                     \n            int level3_int;\n         \
-    \   float level3_float;\n        } level3_union;\n    } level2_struct;\n} moderately_nested_t;\n\
-    \n// Test deeper nesting (level 4)\ntypedef struct {\n    char root_marker;\n\
-    \    struct {\n        int level2_value;\n        struct {\n            float\
-    \ level3_value;\n            union {\n                char level4_char;\n    \
-    \            int level4_int;\n            } level4_data;\n        } level3_struct;\n\
-    \    } level2_container;\n} deeply_nested_t;\n\n// Test mixed structure types\n\
-    typedef struct {\n    int base_id;\n    union {\n        struct {\n          \
-    \  int struct_in_union;\n            char struct_char;\n        } inner_struct;\n\
-    \        int direct_int;\n    } mixed_union;\n} mixed_types_t;\n\n// Test multiple\
-    \ siblings at same level\ntypedef struct {\n    int parent_id;\n    struct {\n\
-    \        int sibling1_value;\n    } sibling1;\n    struct {\n        float sibling2_value;\n\
-    \    } sibling2;\n    union {\n        char sibling3_char;\n        int sibling3_int;\n\
-    \    } sibling3;\n} multiple_siblings_t;\n\n// Global variables using the typedefs\n\
-    moderately_nested_t moderate_var;\ndeeply_nested_t deep_var;\nmixed_types_t mixed_var;\n\
-    multiple_siblings_t siblings_var;\n\n// Functions that use these types\nvoid process_moderate(moderately_nested_t*\
-    \ ptr) {\n    ptr->level1_id = 1;\n    ptr->level2_struct.level2_id = 2;\n}\n\n\
-    void process_deep(deeply_nested_t* ptr) {\n    ptr->root_marker = 'A';\n}\n\n\
-    int main() {\n    process_moderate(&moderate_var);\n    process_deep(&deep_var);\n\
-    \    return 0;\n}\n"
+  anonymous_test.c: |
+    // Test multi-level nested anonymous structures
+    typedef struct\
+        \ {
+        int level1_id;
+        struct {                        
+            int level2_id;
+    \
+        \        union {                     
+                int level3_int;
+             \
+        \   float level3_float;
+            } level3_union;
+        } level2_struct;
+    } moderately_nested_t;
+    \
+        
+    // Test deeper nesting (level 4)
+    typedef struct {
+        char root_marker;
+    \
+        \    struct {
+            int level2_value;
+            struct {
+                float\
+        \ level3_value;
+                union {
+                    char level4_char;
+        \
+        \            int level4_int;
+                } level4_data;
+            } level3_struct;
+    \
+        \    } level2_container;
+    } deeply_nested_t;
+    
+    // Test mixed structure types
+    \
+        typedef struct {
+        int base_id;
+        union {
+            struct {
+              \
+        \  int struct_in_union;
+                char struct_char;
+            } inner_struct;
+    \
+        \        int direct_int;
+        } mixed_union;
+    } mixed_types_t;
+    
+    // Test multiple\
+        \ siblings at same level
+    typedef struct {
+        int parent_id;
+        struct {
+    \
+        \        int sibling1_value;
+        } sibling1;
+        struct {
+            float sibling2_value;
+    \
+        \    } sibling2;
+        union {
+            char sibling3_char;
+            int sibling3_int;
+    \
+        \    } sibling3;
+    } multiple_siblings_t;
+    
+    // Global variables using the typedefs
+    \
+        moderately_nested_t moderate_var;
+    deeply_nested_t deep_var;
+    mixed_types_t mixed_var;
+    \
+        multiple_siblings_t siblings_var;
+    
+    // Functions that use these types
+    void process_moderate(moderately_nested_t*\
+        \ ptr) {
+        ptr->level1_id = 1;
+        ptr->level2_struct.level2_id = 2;
+    }
+    
+    \
+        void process_deep(deeply_nested_t* ptr) {
+        ptr->root_marker = 'A';
+    }
+    
+    \
+        int main() {
+        process_moderate(&moderate_var);
+        process_deep(&deep_var);
+    \
+        \    return 0;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"test_anonymous_processing\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 1\n}\n"
+config.json: |
+  {
+    "project_name": "test_anonymous_processing",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 1
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_105_anon_structs.yml
+++ b/tests/unit/test_105_anon_structs.yml
@@ -6,26 +6,85 @@ test:
   id: '105'
 ---
 source_files:
-  anon_all.c: "// Anonymous struct within typedef with nested union and inner struct\n\
-    typedef struct {\n    int count;\n    struct {\n        int item_id;\n       \
-    \ char item_name[32];\n        union {\n            int int_data;\n          \
-    \  float float_data;\n            struct { int x, y; } point_data;\n        }\
-    \ item_value;\n    } items[10];\n} array_of_anon_structs_t;\n\nvoid process_array(array_of_anon_structs_t*\
-    \ arr) {\n    arr->count = 5;\n    arr->items[0].item_id = 1;\n}\n\narray_of_anon_structs_t\
-    \ global_array;\n\n// Deeply nested anonymous structures\ntypedef struct {\n \
-    \   struct {\n        struct { int level3_field; } level3_struct;\n    } level2_struct;\n\
-    } nested_anonymous_t;\n\nvoid init_nested(nested_anonymous_t* n) { n->level2_struct.level3_struct.level3_field\
-    \ = 42; }\nnested_anonymous_t global_nested = {0};\n\n// Anonymous union within\
-    \ struct\ntypedef struct {\n    int type_id;\n    union {\n        int int_value;\n\
-    \        float float_value;\n        char string_value[64];\n        struct {\
-    \ int x, y, z; } point_value;\n    } data_union;\n    int checksum;\n} struct_with_union_t;\n\
-    \nvoid set_union_data(struct_with_union_t* s, int type) {\n    s->type_id = type;\n\
-    \    if (type == 1) { s->data_union.int_value = 42; }\n    else if (type == 2)\
-    \ { s->data_union.point_value.x = 10; }\n    s->checksum = 0xFF;\n}\n\nstruct_with_union_t\
-    \ global_struct;\n"
+  anon_all.c: |
+    // Anonymous struct within typedef with nested union and inner struct
+    \
+        typedef struct {
+        int count;
+        struct {
+            int item_id;
+           \
+        \ char item_name[32];
+            union {
+                int int_data;
+              \
+        \  float float_data;
+                struct { int x, y; } point_data;
+            }\
+        \ item_value;
+        } items[10];
+    } array_of_anon_structs_t;
+    
+    void process_array(array_of_anon_structs_t*\
+        \ arr) {
+        arr->count = 5;
+        arr->items[0].item_id = 1;
+    }
+    
+    array_of_anon_structs_t\
+        \ global_array;
+    
+    // Deeply nested anonymous structures
+    typedef struct {
+     \
+        \   struct {
+            struct { int level3_field; } level3_struct;
+        } level2_struct;
+    \
+        } nested_anonymous_t;
+    
+    void init_nested(nested_anonymous_t* n) { n->level2_struct.level3_struct.level3_field\
+        \ = 42; }
+    nested_anonymous_t global_nested = {0};
+    
+    // Anonymous union within\
+        \ struct
+    typedef struct {
+        int type_id;
+        union {
+            int int_value;
+    \
+        \        float float_value;
+            char string_value[64];
+            struct {\
+        \ int x, y, z; } point_value;
+        } data_union;
+        int checksum;
+    } struct_with_union_t;
+    \
+        
+    void set_union_data(struct_with_union_t* s, int type) {
+        s->type_id = type;
+    \
+        \    if (type == 1) { s->data_union.int_value = 42; }
+        else if (type == 2)\
+        \ { s->data_union.point_value.x = 10; }
+        s->checksum = 0xFF;
+    }
+    
+    struct_with_union_t\
+        \ global_struct;
+    
 ---
-config.json: "{\n  \"project_name\": \"anonymous_structures_and_unions\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "anonymous_structures_and_unions",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_107_debug_fields_anonymous.yml
+++ b/tests/unit/test_107_debug_fields_anonymous.yml
@@ -4,19 +4,53 @@ test:
   description: Validate nested anonymous structure field parsing and naming conventions
 ---
 source_files:
-  anonymous_fields.c: "typedef struct {\n    int id;\n    struct {\n        char label[32];\n\
-    \        union {\n            int int_val;\n            float float_val;\n   \
-    \     };  // Anonymous union within anonymous struct\n        double precision;\n\
-    \    } config;  // Named anonymous struct field\n    union {\n        struct {\n\
-    \            int width;\n            int height;\n        } dimensions;  // Named\
-    \ struct within anonymous union\n        long area;\n    };  // Anonymous union\n\
-    } container_t;\n\nvoid setup_container(container_t* c) {\n    c->id = 1;\n   \
-    \ c->config.precision = 1.0;\n    c->dimensions.width = 800;\n}\n\ncontainer_t\
-    \ global_container = {0};\n"
+  anonymous_fields.c: |
+    typedef struct {
+        int id;
+        struct {
+            char label[32];
+    \
+        \        union {
+                int int_val;
+                float float_val;
+       \
+        \     };  // Anonymous union within anonymous struct
+            double precision;
+    \
+        \    } config;  // Named anonymous struct field
+        union {
+            struct {
+    \
+        \            int width;
+                int height;
+            } dimensions;  // Named\
+        \ struct within anonymous union
+            long area;
+        };  // Anonymous union
+    \
+        } container_t;
+    
+    void setup_container(container_t* c) {
+        c->id = 1;
+       \
+        \ c->config.precision = 1.0;
+        c->dimensions.width = 800;
+    }
+    
+    container_t\
+        \ global_container = {0};
+    
 ---
-config.json: "{\n  \"project_name\": \"debug_nested_anonymous_structure_fields\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "debug_nested_anonymous_structure_fields",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_107_debug_fields_struct.yml
+++ b/tests/unit/test_107_debug_fields_struct.yml
@@ -5,16 +5,46 @@ test:
     arrays
 ---
 source_files:
-  complex_struct.c: "typedef struct {\n    int base_id;\n    struct {\n        char\
-    \ name[64];\n        float value;\n        struct {\n            int x, y, z;\n\
-    \        } coordinates;\n    } metadata;\n    union {\n        long long_value;\n\
-    \        double double_value;\n    } data_variant;\n    char buffer[256];\n} complex_struct_t;\n\
-    \nvoid init_complex_struct(complex_struct_t* cs) {\n    cs->base_id = 0;\n   \
-    \ cs->metadata.value = 0.0f;\n}\n\ncomplex_struct_t global_complex;\n"
+  complex_struct.c: |
+    typedef struct {
+        int base_id;
+        struct {
+            char\
+        \ name[64];
+            float value;
+            struct {
+                int x, y, z;
+    \
+        \        } coordinates;
+        } metadata;
+        union {
+            long long_value;
+    \
+        \        double double_value;
+        } data_variant;
+        char buffer[256];
+    } complex_struct_t;
+    \
+        
+    void init_complex_struct(complex_struct_t* cs) {
+        cs->base_id = 0;
+       \
+        \ cs->metadata.value = 0.0f;
+    }
+    
+    complex_struct_t global_complex;
+    
 ---
-config.json: "{\n  \"project_name\": \"debug_complex_struct_field_processing\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "debug_complex_struct_field_processing",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_107_debug_fields_union.yml
+++ b/tests/unit/test_107_debug_fields_union.yml
@@ -5,13 +5,35 @@ test:
     field structures are preserved
 ---
 source_files:
-  nested_union.c: "typedef union {\n    int primary_int;\n    union {\n        float\
-    \ nested_float;\n        double nested_double;\n    } nested_union;\n    char\
-    \ primary_bytes[32];\n} test_union_t;\n\nvoid process_union(test_union_t* tu)\
-    \ {\n    tu->primary_int = 42;\n}\n\ntest_union_t global_union;\n"
+  nested_union.c: |
+    typedef union {
+        int primary_int;
+        union {
+            float\
+        \ nested_float;
+            double nested_double;
+        } nested_union;
+        char\
+        \ primary_bytes[32];
+    } test_union_t;
+    
+    void process_union(test_union_t* tu)\
+        \ {
+        tu->primary_int = 42;
+    }
+    
+    test_union_t global_union;
+    
 ---
-config.json: "{\n  \"project_name\": \"debug_nested_union_field_parsing\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "debug_nested_union_field_parsing",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_108_debug_parse_anonymous.yml
+++ b/tests/unit/test_108_debug_parse_anonymous.yml
@@ -5,16 +5,48 @@ test:
   id: '108'
 ---
 source_files:
-  anonymous_struct.c: "// Anonymous struct in typedef\ntypedef struct {\n    int id;\n\
-    \    struct {\n        float x, y;\n    } position;\n    struct {\n        char\
-    \ r, g, b;\n    } color;\n} point_t;\n\n// Anonymous union in typedef\ntypedef\
-    \ struct {\n    int type;\n    union {\n        int int_value;\n        float\
-    \ float_value;\n        char string_value[16];\n    } data;\n} variant_t;\n\n\
-    // Global variable using the types\npoint_t global_point;\nvariant_t global_variant;\n"
+  anonymous_struct.c: |
+    // Anonymous struct in typedef
+    typedef struct {
+        int id;
+    \
+        \    struct {
+            float x, y;
+        } position;
+        struct {
+            char\
+        \ r, g, b;
+        } color;
+    } point_t;
+    
+    // Anonymous union in typedef
+    typedef\
+        \ struct {
+        int type;
+        union {
+            int int_value;
+            float\
+        \ float_value;
+            char string_value[16];
+        } data;
+    } variant_t;
+    
+    \
+        // Global variable using the types
+    point_t global_point;
+    variant_t global_variant;
+    
 ---
-config.json: "{\n  \"project_name\": \"debug_anonymous_structure_parsing\",\n  \"\
-  source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "debug_anonymous_structure_parsing",
+    "\
+    source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_108_debug_parse_struct.yml
+++ b/tests/unit/test_108_debug_parse_struct.yml
@@ -5,14 +5,37 @@ test:
   id: '108'
 ---
 source_files:
-  nested_struct.c: "typedef struct {\n    int outer_id;\n    struct {\n        char\
-    \ name[32];\n        struct {\n            float x, y, z;\n        } position;\n\
-    \    } inner_data;\n    double outer_value;\n} nested_struct_t;\n\n// Function\
-    \ using the nested struct\nvoid process_nested(nested_struct_t* ns) {\n    //\
-    \ Processing function\n}\n"
+  nested_struct.c: |
+    typedef struct {
+        int outer_id;
+        struct {
+            char\
+        \ name[32];
+            struct {
+                float x, y, z;
+            } position;
+    \
+        \    } inner_data;
+        double outer_value;
+    } nested_struct_t;
+    
+    // Function\
+        \ using the nested struct
+    void process_nested(nested_struct_t* ns) {
+        //\
+        \ Processing function
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"debug_nested_struct_parsing\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "debug_nested_struct_parsing",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_108_debug_parse_union.yml
+++ b/tests/unit/test_108_debug_parse_union.yml
@@ -5,13 +5,34 @@ test:
   id: '108'
 ---
 source_files:
-  test_union.c: "typedef union {\n    int primary_int;\n    union {\n        float\
-    \ nested_float;\n        double nested_double;\n    } nested_union;\n    char\
-    \ primary_bytes[32];\n} test_union_t;\n\ntypedef struct {\n    test_union_t data;\n\
-    \    char label[16];\n} container_t;\n"
+  test_union.c: |
+    typedef union {
+        int primary_int;
+        union {
+            float\
+        \ nested_float;
+            double nested_double;
+        } nested_union;
+        char\
+        \ primary_bytes[32];
+    } test_union_t;
+    
+    typedef struct {
+        test_union_t data;
+    \
+        \    char label[16];
+    } container_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"debug_complex_union_parsing\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "debug_complex_union_parsing",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_109_file_spec_cfg.yml
+++ b/tests/unit/test_109_file_spec_cfg.yml
@@ -96,13 +96,31 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"file_specific_configuration_comprehensive\"\
-  ,\n  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true,\n  \"include_depth\": 10,\n  \"file_specific\": {\n    \"main.c\": { \"\
-  include_depth\": 3 },\n    \"sample.c\": {\n      \"include_filter\": [\n      \
-  \  \"^stdio\\\\.h$\", \"^stdlib\\\\.h$\", \"^string\\\\.h$\", \"^sample\\\\.h$\"\
-  ,\n        \"^math_utils\\\\.h$\", \"^logger\\\\.h$\", \"^geometry\\\\.h$\", \"\
-  ^config\\\\.h$\"\n      ],\n      \"include_depth\": 3\n    }\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "file_specific_configuration_comprehensive"\
+    ,
+    "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true,
+    "include_depth": 10,
+    "file_specific": {
+      "main.c": { "\
+    include_depth": 3 },
+      "sample.c": {
+        "include_filter": [
+        \
+    \  "^stdio\\\\.h$", "^stdlib\\\\.h$", "^string\\\\.h$", "^sample\\\\.h$"\
+    ,
+          "^math_utils\\\\.h$", "^logger\\\\.h$", "^geometry\\\\.h$", "\
+    ^config\\\\.h$"
+        ],
+        "include_depth": 3
+      }
+    }
+  }
+  
 ---
 cli_execution:
   steps:

--- a/tests/unit/test_111_gen_exact_params.yml
+++ b/tests/unit/test_111_gen_exact_params.yml
@@ -93,5 +93,8 @@ assertions:
         - "-- Functions --"
       # Test that grouping still works with parameters: public function, empty line, private function
       regex_matches:
-        - pattern: "\\+ int Calculate.*\\n\\s*\\n.*\\- void HelperFunction"
+        - pattern: |
+          \+ int Calculate.*
+          \s*
+          .*\- void HelperFunction
           description: "Public function with parameters, empty line, private function sequence"

--- a/tests/unit/test_111_gen_exact_requested.yml
+++ b/tests/unit/test_111_gen_exact_requested.yml
@@ -116,9 +116,16 @@ assertions:
         - "-- Functions --"
       # Test for exact sequence: public functions, empty line, private functions
       regex_matches:
-        - pattern: "\\+[^\\-]*\\n\\s*\\n[^\\+]*\\-"
+        - pattern: |
+          \+[^\-]*
+          \s*
+          [^\+]*\-
           description: "Empty line between public and private function groups"
       # Test that no private functions appear before empty line and no public after
       regex_not_matches:
-        - pattern: "\\-[^\\n]*\\n[^\\n]*\\+"
+        - pattern: |
+          \-[^
+          ]*
+          [^
+          ]*\+
           description: "Should not have private function followed by public function"

--- a/tests/unit/test_114_preproc.yml
+++ b/tests/unit/test_114_preproc.yml
@@ -6,28 +6,58 @@ test:
   id: '114'
 ---
 source_files:
-  preproc_all.c: "#include <stdio.h>\n#include <stdlib.h>\n#include \"preproc_header.h\"\
-    \n\n// Duplicate macro name under conditional branches\n#if 1\n  #define DEPRECATED\
-    \ __attribute__((deprecated))\n#else\n  #define DEPRECATED\n#endif\n\n// Basic\
-    \ macros\n#define MAX_SIZE 100\n#define MIN_SIZE 10\n#define VERSION_STRING \"\
-    1.0.0\"\n\n// Conditional logging macro\n#ifdef DEBUG\n  #define LOG(msg) printf(\"\
-    DEBUG: %s\\n\", msg)\n#else\n  #define LOG(msg)\n#endif\n\ntypedef struct {\n\
-    \  int id;\n  char name[MAX_SIZE];\n} Item;\n\n#if defined(FEATURE_A)\n  typedef\
-    \ struct { int feature_a_data; } FeatureA;\n#endif\n\n#ifndef DISABLE_FEATURE_B\n\
-    \  typedef struct { float feature_b_value; } FeatureB;\n#endif\n\nint process_item(Item*\
-    \ item);\nvoid initialize_system(void);\n\nint global_items = 0;\n\nint process_item(Item*\
-    \ item) {\n  if (item == NULL) return -1;\n  LOG(\"Processing item\");\n  return\
-    \ item->id;\n}\n\nvoid initialize_system(void) {\n  LOG(\"System initialized\"\
-    );\n  global_items = 0;\n}\n"
-  preproc_header.h: "#ifndef PREPROCESSOR_HEADER_H\n#define PREPROCESSOR_HEADER_H\n\
-    \n#define HEADER_VERSION 2\n#define API_VERSION \"2.1.0\"\n\ntypedef struct Item\
-    \ Item;\n\n#ifdef FEATURE_A\n  typedef struct FeatureA FeatureA;\n#endif\n\n#ifndef\
-    \ DISABLE_FEATURE_B\n  typedef struct FeatureB FeatureB;\n#endif\n\nint process_item(Item*\
-    \ item);\nvoid initialize_system(void);\n\n#endif // PREPROCESSOR_HEADER_H\n"
+  preproc_all.c: |
+    #include <stdio.h>n#include <stdlib.h>n#include "preproc_header.h"
+        nn// Duplicate macro name under conditional branchesn#if 1n  #define DEPRECATED
+         __attribute__((deprecated))n#elsen  #define DEPRECATEDn#endifnn// Basic
+         macrosn#define MAX_SIZE 100n#define MIN_SIZE 10n#define VERSION_STRING "
+        1.0.0"nn// Conditional logging macron#ifdef DEBUGn  #define LOG(msg) printf("
+        DEBUG: %s
+    ", msg)n#elsen  #define LOG(msg)n#endifnntypedef struct {n
+          int id;n  char name[MAX_SIZE];n} Item;nn#if defined(FEATURE_A)n  typedef
+         struct { int feature_a_data; } FeatureA;n#endifnn#ifndef DISABLE_FEATURE_Bn
+          typedef struct { float feature_b_value; } FeatureB;n#endifnnint process_item(Item*
+         item);nvoid initialize_system(void);nnint global_items = 0;nnint process_item(Item*
+         item) {n  if (item == NULL) return -1;n  LOG("Processing item");n  return
+         item->id;n}nnvoid initialize_system(void) {n  LOG("System initialized"
+        );n  global_items = 0;n}n
+  preproc_header.h: |
+    #ifndef PREPROCESSOR_HEADER_H
+    #define PREPROCESSOR_HEADER_H
+    \
+        
+    #define HEADER_VERSION 2
+    #define API_VERSION "2.1.0"
+    
+    typedef struct Item\
+        \ Item;
+    
+    #ifdef FEATURE_A
+      typedef struct FeatureA FeatureA;
+    #endif
+    
+    #ifndef\
+        \ DISABLE_FEATURE_B
+      typedef struct FeatureB FeatureB;
+    #endif
+    
+    int process_item(Item*\
+        \ item);
+    void initialize_system(void);
+    
+    #endif // PREPROCESSOR_HEADER_H
+    
 ---
-config.json: "{\n  \"project_name\": \"preprocessor_and_macros_comprehensive\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "preprocessor_and_macros_comprehensive",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_115_parser_basics.yml
+++ b/tests/unit/test_115_parser_basics.yml
@@ -6,13 +6,35 @@ test:
   id: '115'
 ---
 source_files:
-  complete.c: "#include <stdio.h>\n#define VERSION \"1.0.0\"\n\ntypedef struct User\
-    \ {\n    int id;\n    const char * name;\n} User;\n\nenum Mode { MODE_A, MODE_B\
-    \ };\n\nint global_counter = 0;\n\nstatic int helper(int x) { return x + 1; }\n\
-    int add(int a, int b) { return a + b; }\n"
+  complete.c: |
+    #include <stdio.h>
+    #define VERSION "1.0.0"
+    
+    typedef struct User\
+        \ {
+        int id;
+        const char * name;
+    } User;
+    
+    enum Mode { MODE_A, MODE_B\
+        \ };
+    
+    int global_counter = 0;
+    
+    static int helper(int x) { return x + 1; }
+    \
+        int add(int a, int b) { return a + b; }
+    
 ---
-config.json: "{\n  \"project_name\": \"test_parser_comprehensive_basics\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_parser_comprehensive_basics",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_116_struct_order.yml
+++ b/tests/unit/test_116_struct_order.yml
@@ -6,18 +6,49 @@ test:
   id: '116'
 ---
 source_files:
-  struct_order.c: "typedef struct triangle_tag {\n    point_t vertices[3];\n    char\
-    \ label[MAX_LABEL_LEN];\n} triangle_t;\n"
-  struct_order_puml.c: "typedef struct triangle_tag {\n    point_t vertices[3];\n\
-    \    char label[MAX_LABEL_LEN];\n} triangle_t;\n"
-  struct_order_complex.c: "typedef struct complex_struct {\n    int id;\n    char\
-    \ name[32];\n    float value;\n    struct {\n        int x;\n        int y;\n\
-    \    } position;\n    union {\n        int int_data;\n        float float_data;\n\
-    \    } data;\n} complex_struct_t;\n"
+  struct_order.c: |
+    typedef struct triangle_tag {
+        point_t vertices[3];
+        char\
+        \ label[MAX_LABEL_LEN];
+    } triangle_t;
+    
+  struct_order_puml.c: |
+    typedef struct triangle_tag {
+        point_t vertices[3];
+    \
+        \    char label[MAX_LABEL_LEN];
+    } triangle_t;
+    
+  struct_order_complex.c: |
+    typedef struct complex_struct {
+        int id;
+        char\
+        \ name[32];
+        float value;
+        struct {
+            int x;
+            int y;
+    \
+        \    } position;
+        union {
+            int int_data;
+            float float_data;
+    \
+        \    } data;
+    } complex_struct_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"struct_and_nested_ordering_comprehensive\"\
-  ,\n  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "struct_and_nested_ordering_comprehensive"\
+    ,
+    "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_117_tokenizer_comp.yml
+++ b/tests/unit/test_117_tokenizer_comp.yml
@@ -6,106 +6,265 @@ test:
   id: '117'
 ---
 source_files:
-  complex.c: "#include <stdio.h>\n#include <stdlib.h>\n\n// Complex typedefs with\
-    \ function pointers\ntypedef struct Node {\n    int data;\n    struct Node* next;\n\
-    \    int (*compare)(const void* a, const void* b);\n    void (*callback)(struct\
-    \ Node* self, void* context);\n} Node;\n\n// Complex enum with explicit values\n\
-    typedef enum {\n    STATE_INIT = 0x01,\n    STATE_RUNNING = 0x02,\n    STATE_PAUSED\
-    \ = 0x04,\n    STATE_STOPPED = 0x08,\n    STATE_ERROR = 0xFF\n} SystemState;\n\
-    \n// Complex union with nested structs\ntypedef union {\n    struct {\n      \
-    \  uint8_t r, g, b, a;\n    } color;\n    uint32_t value;\n    struct {\n    \
-    \    uint16_t high;\n        uint16_t low;\n    } words;\n} ColorUnion;\n\n//\
-    \ Complex function with multiple pointer levels\nint** allocate_matrix(size_t\
-    \ rows, size_t cols);\n\n// Function with complex parameter types\nvoid process_data(\n\
-    \    const Node* const * nodes,\n    size_t count,\n    int (*processor)(const\
-    \ Node*, void*),\n    void* context\n);\n\n// Simple global variable\nstatic int\
-    \ global_counter = 0;\n\n// Complex macro with multi-line definition\n#define\
-    \ SAFE_FREE(ptr) do { \\\n    if ((ptr) != NULL) { \\\n        free(ptr); \\\n\
-    \        (ptr) = NULL; \\\n    } \\\n} while(0)\n\n// Function with complex body\
-    \ that tests expression parsing\nNode* create_node(int data) {\n    Node* node\
-    \ = (Node*)malloc(sizeof(Node));\n    if (node != NULL) {\n        node->data\
-    \ = data;\n        node->next = NULL;\n        node->compare = NULL;\n       \
-    \ node->callback = NULL;\n    }\n    return node;\n}\n"
-  edge_cases.c: "#include <stdio.h>\n#include <string.h>\n\n/* Multi-line comment\
-    \ with\n   complex content like:\n   struct fake { int x; };\n   This should be\
-    \ ignored */\n\n// Single line comment with code: int y = 5;\n\nstruct EdgeCase\
-    \ {\n    char string_with_quotes[50];  // \"embedded quotes\"\n    char escaped_chars[20];\
-    \       // contains \\n, \\t, \\\\, \\\"\n    int complex_expr;             //\
-    \ result of (a * b + c) / d\n};\n\n// String literals with special content\nconst\
-    \ char* test_strings[] = {\n    \"Simple string\",\n    \"String with \\\"escaped\
-    \ quotes\\\"\",\n    \"String with \\\\ backslash\",\n    \"String with \\n newline\"\
-    ,\n    \"Multi line string\",\n    \"\"  // Empty string\n};\n\n// Complex expressions\
-    \ with multiple operators\nint complex_calculation() {\n    int a = 10, b = 20,\
-    \ c = 30;\n    int result1 = ((a + b) * c - (a / b)) % 7;\n    int result2 = (a\
-    \ << 2) | (b >> 1) & ~c;\n    int result3 = (a > b) ? (c * 2) : (c / 2);\n   \
-    \ return strlen(\"test\") + result1 + result2 + result3;\n}\n\n// Macro with complex\
-    \ content\n#define COMPLEX_MACRO(x, y) \\\n    do { \\\n        if ((x) > (y))\
-    \ { \\\n            printf(\"x=%d > y=%d\\n\", (x), (y)); \\\n        } else {\
-    \ \\\n            printf(\"x=%d <= y=%d\\n\", (x), (y)); \\\n        } \\\n  \
-    \  } while(0)\n\n// Edge case: function with many punctuation marks\nvoid punctuation_test(int\
-    \ array[], size_t len, int (*cmp)(const void*, const void*)) {\n    int* ptr =\
-    \ &array[0];\n    (*ptr)++;\n    array[len-1] = *ptr;\n}\n"
-  preprocessor.c: "#include <stdio.h>\n#include <stdlib.h>\n\n// Complex conditional\
-    \ compilation\n#ifdef DEBUG\n    #define LOG(msg) printf(\"DEBUG: %s\\n\", msg)\n\
-    \    #define DEBUG_ONLY(code) code\n#else\n    #define LOG(msg) \n    #define\
-    \ DEBUG_ONLY(code)\n#endif\n\n// Multi-level nested preprocessor conditions\n\
-    #if defined(FEATURE_A) && !defined(FEATURE_B)\n    #ifdef PLATFORM_LINUX\n   \
-    \     #define PLATFORM_SPECIFIC_FUNC linux_func\n    #elif defined(PLATFORM_WINDOWS)\n\
-    \        #define PLATFORM_SPECIFIC_FUNC windows_func\n    #else\n        #define\
-    \ PLATFORM_SPECIFIC_FUNC generic_func\n    #endif\n#else\n    #define PLATFORM_SPECIFIC_FUNC\
-    \ default_func\n#endif\n\n// Preprocessor with complex expressions\n#define MAX(a,\
-    \ b) ((a) > (b) ? (a) : (b))\n#define MIN(a, b) ((a) < (b) ? (a) : (b))\n#define\
-    \ CLAMP(x, min, max) MIN(MAX(x, min), max)\n\n// Macro with stringification and\
-    \ token pasting\n#define DECLARE_FUNC(name) \\\n    void name##_init(void); \\\
-    \n    void name##_cleanup(void); \\\n    const char* name##_get_name(void) { return\
-    \ #name; }\n\nstruct Config {\n    int base_value;\n#ifdef EXTENDED_CONFIG\n \
-    \   int extended_value;\n    char* description;\n#endif\n#if MAX_FEATURES > 10\n\
-    \    int feature_flags[MAX_FEATURES];\n#else\n    int feature_flags[10];\n#endif\n\
-    };\n\nint calculate_result(int input) {\n    int result = input;\n#ifdef APPLY_MULTIPLIER\n\
-    \    result *= 2;\n#endif\n#ifndef DISABLE_BOUNDS_CHECK\n    if (result < 0) result\
-    \ = 0;\n    if (result > 1000) result = 1000;\n#endif\n    DEBUG_ONLY(LOG(\"Result\
-    \ calculated\"));\n    return result;\n}\n\n#define COMPLEX_OPERATION(x, y, z)\
-    \ \\\n    do { \\\n        int temp1 = (x) + (y); \\\n        int temp2 = temp1\
-    \ * (z); \\\n        printf(\"Operation: %d + %d = %d, * %d = %d\\n\", \\\n  \
-    \             (x), (y), temp1, (z), temp2); \\\n    } while(0)\n\nDECLARE_FUNC(module_a)\n\
-    DECLARE_FUNC(module_b)\n"
-  complex_functions.c: "#include <stdarg.h>\n\nstruct complex_struct;\ntypedef struct\
-    \ complex_struct complex_t;\n\ntypedef void (*callback_t)(int result, void* user_data);\n\
-    typedef int (*comparator_t)(const void* a, const void* b);\n\nint complex_function(\n\
-    \    const char* name,\n    complex_t* data,\n    callback_t callback,\n    void*\
-    \ user_data,\n    int flags,\n    ...  // variadic parameters\n);\n\nstatic complex_t*\
-    \ create_complex(\n    const char* name,\n    size_t name_len,\n    int initial_value\n\
-    ) {\n    return NULL;\n}\n\ncomparator_t get_comparator(\n    const char* type,\n\
-    \    int (*custom_compare)(const void*, const void*)\n);\n\ninline void process_array(\n\
-    \    complex_t** array,\n    size_t count,\n    void (*processor)(complex_t*,\
-    \ int index)\n) {}\n\nvoid log_message(int level, const char* format, ...);\n\
-    const volatile int* get_status_pointer(void);\n"
-  mixed_structures.c: "#include <stdio.h>\n#include <stdlib.h>\n\ntypedef enum {\n\
-    \    STATE_IDLE = 0,\n    STATE_RUNNING = 1,\n    STATE_PAUSED = 2,\n    STATE_ERROR\
-    \ = -1\n} state_t;\n\ntypedef struct {\n    char name[64];\n    state_t current_state;\n\
-    \    struct {\n        int x, y, z;\n        union {\n            float as_float[3];\n\
-    \            int as_int[3];\n        } coordinates;\n    } position;\n    union\
-    \ {\n        struct {\n            char type;\n            int value;\n      \
-    \  } typed_data;\n        float raw_float;\n        int raw_int;\n    } data;\n\
-    } complex_entity_t;\n\ntypedef int (*process_func_t)(complex_entity_t*, state_t);\n\
-    \nint process_entity(complex_entity_t* entity, state_t new_state) {\n    if (entity\
-    \ && new_state >= STATE_IDLE) {\n        entity->current_state = new_state;\n\
-    \        return 1;\n    }\n    return 0;\n}\n\ncomplex_entity_t global_entity;\n\
-    process_func_t global_processor = process_entity;\n"
-  complex_union.c: "typedef union {\n    int primary_int;\n    union {\n        float\
-    \ nested_float;\n        double nested_double;\n        union {\n            char\
-    \ deep_char;\n            short deep_short;\n        } deep_union;\n    } nested_union;\n\
-    \    char primary_bytes[32];\n    struct {\n        int struct_in_union;\n   \
-    \     float struct_float;\n    } embedded_struct;\n} complex_union_t;\n\nvoid\
-    \ process_complex_union(complex_union_t* cu) {}\ncomplex_union_t global_complex_union;\n"
-  keywords.c: "struct DataStruct {\n    int value;\n    const char* name;\n};\n\n\
-    enum DataEnum {\n    OPTION_A,\n    OPTION_B\n};\n\nunion DataUnion {\n    int\
-    \ intVal;\n    float floatVal;\n};\n\nstatic int static_var = 10;\nextern int\
-    \ extern_var;\n\ninline void inline_func() {}\nvoid regular_func(const void* ptr)\
-    \ {}\n"
+  complex.c: |
+    #include <stdio.h>n#include <stdlib.h>nn// Complex typedefs with
+         function pointersntypedef struct Node {n    int data;n    struct Node* next;n
+            int (*compare)(const void* a, const void* b);n    void (*callback)(struct
+         Node* self, void* context);n} Node;nn// Complex enum with explicit valuesn
+        typedef enum {n    STATE_INIT = 0x01,n    STATE_RUNNING = 0x02,n    STATE_PAUSED
+         = 0x04,n    STATE_STOPPED = 0x08,n    STATE_ERROR = 0xFFn} SystemState;n
+        n// Complex union with nested structsntypedef union {n    struct {n      
+          uint8_t r, g, b, a;n    } color;n    uint32_t value;n    struct {n    
+            uint16_t high;n        uint16_t low;n    } words;n} ColorUnion;nn//
+         Complex function with multiple pointer levelsnint** allocate_matrix(size_t
+         rows, size_t cols);nn// Function with complex parameter typesnvoid process_data(n
+            const Node* const * nodes,n    size_t count,n    int (*processor)(const
+         Node*, void*),n    void* contextn);nn// Simple global variablenstatic int
+         global_counter = 0;nn// Complex macro with multi-line definitionn#define
+         SAFE_FREE(ptr) do { 
+        if ((ptr) != NULL) { 
+            free(ptr); 
+    
+                (ptr) = NULL; 
+        } 
+    } while(0)nn// Function with complex body
+         that tests expression parsingnNode* create_node(int data) {n    Node* node
+         = (Node*)malloc(sizeof(Node));n    if (node != NULL) {n        node->data
+         = data;n        node->next = NULL;n        node->compare = NULL;n       
+         node->callback = NULL;n    }n    return node;n}n
+  edge_cases.c: |
+    #include <stdio.h>n#include <string.h>nn/* Multi-line comment
+         withn   complex content like:n   struct fake { int x; };n   This should be
+         ignored */nn// Single line comment with code: int y = 5;nnstruct EdgeCase
+         {n    char string_with_quotes[50];  // "embedded quotes"n    char escaped_chars[20];
+               // contains 
+    , \t, \\, "n    int complex_expr;             //
+         result of (a * b + c) / dn};nn// String literals with special contentnconst
+         char* test_strings[] = {n    "Simple string",n    "String with "escaped
+         quotes"",n    "String with \\ backslash",n    "String with 
+     newline"
+        ,n    "Multi line string",n    ""  // Empty stringn};nn// Complex expressions
+         with multiple operatorsnint complex_calculation() {n    int a = 10, b = 20,
+         c = 30;n    int result1 = ((a + b) * c - (a / b)) % 7;n    int result2 = (a
+         << 2) | (b >> 1) & ~c;n    int result3 = (a > b) ? (c * 2) : (c / 2);n   
+         return strlen("test") + result1 + result2 + result3;n}nn// Macro with complex
+         contentn#define COMPLEX_MACRO(x, y) 
+        do { 
+            if ((x) > (y))
+         { 
+                printf("x=%d > y=%d
+    ", (x), (y)); 
+            } else {
+         
+                printf("x=%d <= y=%d
+    ", (x), (y)); 
+            } 
+      
+          } while(0)nn// Edge case: function with many punctuation marksnvoid punctuation_test(int
+         array[], size_t len, int (*cmp)(const void*, const void*)) {n    int* ptr =
+         &array[0];n    (*ptr)++;n    array[len-1] = *ptr;n}n
+  preprocessor.c: |
+    #include <stdio.h>n#include <stdlib.h>nn// Complex conditional
+         compilationn#ifdef DEBUGn    #define LOG(msg) printf("DEBUG: %s
+    ", msg)n
+            #define DEBUG_ONLY(code) coden#elsen    #define LOG(msg) n    #define
+         DEBUG_ONLY(code)n#endifnn// Multi-level nested preprocessor conditionsn
+        #if defined(FEATURE_A) && !defined(FEATURE_B)n    #ifdef PLATFORM_LINUXn   
+             #define PLATFORM_SPECIFIC_FUNC linux_funcn    #elif defined(PLATFORM_WINDOWS)n
+                #define PLATFORM_SPECIFIC_FUNC windows_funcn    #elsen        #define
+         PLATFORM_SPECIFIC_FUNC generic_funcn    #endifn#elsen    #define PLATFORM_SPECIFIC_FUNC
+         default_funcn#endifnn// Preprocessor with complex expressionsn#define MAX(a,
+         b) ((a) > (b) ? (a) : (b))n#define MIN(a, b) ((a) < (b) ? (a) : (b))n#define
+         CLAMP(x, min, max) MIN(MAX(x, min), max)nn// Macro with stringification and
+         token pastingn#define DECLARE_FUNC(name) 
+        void name##_init(void); \
+        n    void name##_cleanup(void); 
+        const char* name##_get_name(void) { return
+         #name; }nnstruct Config {n    int base_value;n#ifdef EXTENDED_CONFIGn 
+           int extended_value;n    char* description;n#endifn#if MAX_FEATURES > 10n
+            int feature_flags[MAX_FEATURES];n#elsen    int feature_flags[10];n#endifn
+        };nnint calculate_result(int input) {n    int result = input;n#ifdef APPLY_MULTIPLIERn
+            result *= 2;n#endifn#ifndef DISABLE_BOUNDS_CHECKn    if (result < 0) result
+         = 0;n    if (result > 1000) result = 1000;n#endifn    DEBUG_ONLY(LOG("Result
+         calculated"));n    return result;n}nn#define COMPLEX_OPERATION(x, y, z)
+         
+        do { 
+            int temp1 = (x) + (y); 
+            int temp2 = temp1
+         * (z); 
+            printf("Operation: %d + %d = %d, * %d = %d
+    ", 
+      
+                     (x), (y), temp1, (z), temp2); 
+        } while(0)nnDECLARE_FUNC(module_a)n
+        DECLARE_FUNC(module_b)n
+  complex_functions.c: |
+    #include <stdarg.h>
+    
+    struct complex_struct;
+    typedef struct\
+        \ complex_struct complex_t;
+    
+    typedef void (*callback_t)(int result, void* user_data);
+    \
+        typedef int (*comparator_t)(const void* a, const void* b);
+    
+    int complex_function(
+    \
+        \    const char* name,
+        complex_t* data,
+        callback_t callback,
+        void*\
+        \ user_data,
+        int flags,
+        ...  // variadic parameters
+    );
+    
+    static complex_t*\
+        \ create_complex(
+        const char* name,
+        size_t name_len,
+        int initial_value
+    \
+        ) {
+        return NULL;
+    }
+    
+    comparator_t get_comparator(
+        const char* type,
+    \
+        \    int (*custom_compare)(const void*, const void*)
+    );
+    
+    inline void process_array(
+    \
+        \    complex_t** array,
+        size_t count,
+        void (*processor)(complex_t*,\
+        \ int index)
+    ) {}
+    
+    void log_message(int level, const char* format, ...);
+    \
+        const volatile int* get_status_pointer(void);
+    
+  mixed_structures.c: |
+    #include <stdio.h>
+    #include <stdlib.h>
+    
+    typedef enum {
+    \
+        \    STATE_IDLE = 0,
+        STATE_RUNNING = 1,
+        STATE_PAUSED = 2,
+        STATE_ERROR\
+        \ = -1
+    } state_t;
+    
+    typedef struct {
+        char name[64];
+        state_t current_state;
+    \
+        \    struct {
+            int x, y, z;
+            union {
+                float as_float[3];
+    \
+        \            int as_int[3];
+            } coordinates;
+        } position;
+        union\
+        \ {
+            struct {
+                char type;
+                int value;
+          \
+        \  } typed_data;
+            float raw_float;
+            int raw_int;
+        } data;
+    \
+        } complex_entity_t;
+    
+    typedef int (*process_func_t)(complex_entity_t*, state_t);
+    \
+        
+    int process_entity(complex_entity_t* entity, state_t new_state) {
+        if (entity\
+        \ && new_state >= STATE_IDLE) {
+            entity->current_state = new_state;
+    \
+        \        return 1;
+        }
+        return 0;
+    }
+    
+    complex_entity_t global_entity;
+    \
+        process_func_t global_processor = process_entity;
+    
+  complex_union.c: |
+    typedef union {
+        int primary_int;
+        union {
+            float\
+        \ nested_float;
+            double nested_double;
+            union {
+                char\
+        \ deep_char;
+                short deep_short;
+            } deep_union;
+        } nested_union;
+    \
+        \    char primary_bytes[32];
+        struct {
+            int struct_in_union;
+       \
+        \     float struct_float;
+        } embedded_struct;
+    } complex_union_t;
+    
+    void\
+        \ process_complex_union(complex_union_t* cu) {}
+    complex_union_t global_complex_union;
+    
+  keywords.c: |
+    struct DataStruct {
+        int value;
+        const char* name;
+    };
+    
+    \
+        enum DataEnum {
+        OPTION_A,
+        OPTION_B
+    };
+    
+    union DataUnion {
+        int\
+        \ intVal;
+        float floatVal;
+    };
+    
+    static int static_var = 10;
+    extern int\
+        \ extern_var;
+    
+    inline void inline_func() {}
+    void regular_func(const void* ptr)\
+        \ {}
+    
 ---
-config.json: "{\n  \"project_name\": \"test_tokenizer_comprehensive\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_tokenizer_comprehensive",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_118_token_keywords.yml
+++ b/tests/unit/test_118_token_keywords.yml
@@ -6,14 +6,47 @@ test:
   id: '118'
 ---
 source_files:
-  keywords.c: "struct DataStruct {\n    int value;\n    const char* name;\n};\n\n\
-    enum DataEnum {\n    OPTION_A,\n    OPTION_B\n};\n\nunion DataUnion {\n    int\
-    \ intVal;\n    float floatVal;\n};\n\nstatic int static_var = 10;\nextern int\
-    \ extern_var;\n\ninline void inline_func() {\n    // inline function\n}\n\nvoid\
-    \ regular_func(const void* ptr) {\n    // regular function\n}\n"
+  keywords.c: |
+    struct DataStruct {
+        int value;
+        const char* name;
+    };
+    
+    \
+        enum DataEnum {
+        OPTION_A,
+        OPTION_B
+    };
+    
+    union DataUnion {
+        int\
+        \ intVal;
+        float floatVal;
+    };
+    
+    static int static_var = 10;
+    extern int\
+        \ extern_var;
+    
+    inline void inline_func() {
+        // inline function
+    }
+    
+    void\
+        \ regular_func(const void* ptr) {
+        // regular function
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"test_tokenizer_keywords\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_tokenizer_keywords",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_119_trans_comp.yml
+++ b/tests/unit/test_119_trans_comp.yml
@@ -79,20 +79,53 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"transformer_consolidated\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  transformations\": {\n    \"remove\": {\n      \"structs\": [\"^Temp.*\"],\n   \
-  \   \"enums\": [\"TempStatus\"],\n      \"functions\": [\"temp_.*\"],\n      \"\
-  globals\": [\"temp_.*\"],\n      \"macros\": [\"UNUSED_.*\"]\n    },\n    \"rename\"\
-  : {\n      \"structs\": {\"DataItem\": \"ProcessedItem\", \"MainData\": \"ProcessedMainData\"\
-  },\n      \"enums\": {\"Status\": \"ProcessStatus\"},\n      \"functions\": {\"\
-  process_data\": \"transform_data\", \"main_function\": \"processed_main_function\"\
-  },\n      \"globals\": {\"global_counter\": \"item_counter\"},\n      \"macros\"\
-  : {\"DEBUG_MODE\": \"TRACE_MODE\"}\n    },\n    \"file_filters\": {\n      \"include_patterns\"\
-  : [\"main.*\", \"utils.*\"],\n      \"exclude_patterns\": [\"temp.*\"]\n    },\n\
-  \    \"include_depth\": 2,\n    \"include_filters\": {\n      \"depth\": 1,\n  \
-  \    \"file_specific\": {\"main.c\": {\"include_depth\": 2}}\n    },\n    \"file_selection\"\
-  : [\"main.c\"]\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "transformer_consolidated",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    transformations": {
+      "remove": {
+        "structs": ["^Temp.*"],
+     \
+    \   "enums": ["TempStatus"],
+        "functions": ["temp_.*"],
+        "\
+    globals": ["temp_.*"],
+        "macros": ["UNUSED_.*"]
+      },
+      "rename"\
+    : {
+        "structs": {"DataItem": "ProcessedItem", "MainData": "ProcessedMainData"\
+    },
+        "enums": {"Status": "ProcessStatus"},
+        "functions": {"\
+    process_data": "transform_data", "main_function": "processed_main_function"\
+    },
+        "globals": {"global_counter": "item_counter"},
+        "macros"\
+    : {"DEBUG_MODE": "TRACE_MODE"}
+      },
+      "file_filters": {
+        "include_patterns"\
+    : ["main.*", "utils.*"],
+        "exclude_patterns": ["temp.*"]
+      },
+  \
+    \    "include_depth": 2,
+      "include_filters": {
+        "depth": 1,
+    \
+    \    "file_specific": {"main.c": {"include_depth": 2}}
+      },
+      "file_selection"\
+    : ["main.c"]
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_120_typedef_extr.yml
+++ b/tests/unit/test_120_typedef_extr.yml
@@ -6,32 +6,122 @@ test:
   id: '120'
 ---
 source_files:
-  typedefs_all.c: "// Simple typedefs\ntypedef uint32_t MyLen;\ntypedef int32_t MyInt;\n\
-    typedef char * MyString;\ntypedef unsigned long long ULongLong;\ntypedef const\
-    \ char * ConstString;\ntypedef volatile int VolatileInt;\n\n// Function pointer\
-    \ typedefs\ntypedef int (*MyCallback)(struct MyBuffer_tag * buffer);\ntypedef\
-    \ void (*log_callback_t)(enum log_level_tag level, const char * message);\ntypedef\
-    \ int (*complex_callback)(int a, int b, char * str);\ntypedef void (*simple_func_ptr)(void);\n\
-    typedef char * (*string_processor)(const char * input, int len);\ntypedef int\
-    \ (*calculator)(int x, int y);\n\n// Struct typedefs\ntypedef struct MyBuffer_tag\
-    \ {\n    MyLen length;\n    MyString data;\n} MyBuffer;\n\ntypedef struct MyComplexStruct_tag\
-    \ {\n    MyLen id;\n    MyString name;\n    MyCallback callback;\n    enum log_level_tag\
-    \ log_level;\n} MyComplex;\n\ntypedef struct point_tag {\n    int x;\n    int\
-    \ y;\n} point_t;\n\ntypedef struct Person {\n    char name[50];\n    int age;\n\
-    \    char *address;\n} Person_t;\n\n// Enum typedefs\ntypedef enum Color_tag {\n\
-    \    COLOR_RED,\n    COLOR_GREEN,\n    COLOR_BLUE\n} Color_t;\n\ntypedef enum\
-    \ log_level_tag {\n    LOG_DEBUG,\n    LOG_INFO,\n    LOG_WARN,\n    LOG_ERROR\n\
-    } log_level_t;\n\ntypedef enum Status_tag {\n    STATUS_OK,\n    STATUS_ERROR,\n\
-    \    STATUS_PENDING\n} Status_t;\n\n// Union typedefs\ntypedef union Number_tag\
-    \ {\n    int i;\n    float f;\n    double d;\n} Number_t;\n\ntypedef union NamedUnion_tag\
-    \ {\n    char c;\n    int i;\n    short s;\n} NamedUnion_t;\n\ntypedef union Value\
-    \ {\n    int integer_value;\n    float float_value;\n    char string_value[32];\n\
-    } Value_t;\n\n// Pointers and arrays of typedefs\ntypedef MyComplex * MyComplexPtr;\n\
-    typedef MyComplexPtr MyComplexArray[10];\n"
+  typedefs_all.c: |
+    // Simple typedefs
+    typedef uint32_t MyLen;
+    typedef int32_t MyInt;
+    \
+        typedef char * MyString;
+    typedef unsigned long long ULongLong;
+    typedef const\
+        \ char * ConstString;
+    typedef volatile int VolatileInt;
+    
+    // Function pointer\
+        \ typedefs
+    typedef int (*MyCallback)(struct MyBuffer_tag * buffer);
+    typedef\
+        \ void (*log_callback_t)(enum log_level_tag level, const char * message);
+    typedef\
+        \ int (*complex_callback)(int a, int b, char * str);
+    typedef void (*simple_func_ptr)(void);
+    \
+        typedef char * (*string_processor)(const char * input, int len);
+    typedef int\
+        \ (*calculator)(int x, int y);
+    
+    // Struct typedefs
+    typedef struct MyBuffer_tag\
+        \ {
+        MyLen length;
+        MyString data;
+    } MyBuffer;
+    
+    typedef struct MyComplexStruct_tag\
+        \ {
+        MyLen id;
+        MyString name;
+        MyCallback callback;
+        enum log_level_tag\
+        \ log_level;
+    } MyComplex;
+    
+    typedef struct point_tag {
+        int x;
+        int\
+        \ y;
+    } point_t;
+    
+    typedef struct Person {
+        char name[50];
+        int age;
+    \
+        \    char *address;
+    } Person_t;
+    
+    // Enum typedefs
+    typedef enum Color_tag {
+    \
+        \    COLOR_RED,
+        COLOR_GREEN,
+        COLOR_BLUE
+    } Color_t;
+    
+    typedef enum\
+        \ log_level_tag {
+        LOG_DEBUG,
+        LOG_INFO,
+        LOG_WARN,
+        LOG_ERROR
+    \
+        } log_level_t;
+    
+    typedef enum Status_tag {
+        STATUS_OK,
+        STATUS_ERROR,
+    \
+        \    STATUS_PENDING
+    } Status_t;
+    
+    // Union typedefs
+    typedef union Number_tag\
+        \ {
+        int i;
+        float f;
+        double d;
+    } Number_t;
+    
+    typedef union NamedUnion_tag\
+        \ {
+        char c;
+        int i;
+        short s;
+    } NamedUnion_t;
+    
+    typedef union Value\
+        \ {
+        int integer_value;
+        float float_value;
+        char string_value[32];
+    \
+        } Value_t;
+    
+    // Pointers and arrays of typedefs
+    typedef MyComplex * MyComplexPtr;
+    \
+        typedef MyComplexPtr MyComplexArray[10];
+    
 ---
-config.json: "{\n  \"project_name\": \"test_typedef_extraction_comprehensive\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "test_typedef_extraction_comprehensive",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_120_typedef_extr_edge.yml
+++ b/tests/unit/test_120_typedef_extr_edge.yml
@@ -5,18 +5,49 @@ test:
   id: '120'
 ---
 source_files:
-  edge_cases_typedefs.c: "// Edge cases for typedef extraction\n\n// This is a comment\n\
-    typedef uint32_t MyLen;  // Another comment\n\n/* Multi-line comment\n   about\
-    \ typedefs */\ntypedef int32_t MyInt;\n\ntypedef char * MyString; /* Inline comment\
-    \ */\n\n// Typedef with extra whitespace\ntypedef  unsigned   long   long    ULongLong\
-    \  ;\n\n// Typedef with const and volatile\ntypedef const char * ConstString;\n\
-    typedef volatile int VolatileInt;\n\n/* Complex typedef with nested comments */\n\
-    typedef struct /* comment */ Point_tag {\n    int x; // X coordinate\n    int\
-    \ y; /* Y coordinate */\n} Point_t;\n"
+  edge_cases_typedefs.c: |
+    // Edge cases for typedef extraction
+    
+    // This is a comment
+    \
+        typedef uint32_t MyLen;  // Another comment
+    
+    /* Multi-line comment
+       about\
+        \ typedefs */
+    typedef int32_t MyInt;
+    
+    typedef char * MyString; /* Inline comment\
+        \ */
+    
+    // Typedef with extra whitespace
+    typedef  unsigned   long   long    ULongLong\
+        \  ;
+    
+    // Typedef with const and volatile
+    typedef const char * ConstString;
+    \
+        typedef volatile int VolatileInt;
+    
+    /* Complex typedef with nested comments */
+    \
+        typedef struct /* comment */ Point_tag {
+        int x; // X coordinate
+        int\
+        \ y; /* Y coordinate */
+    } Point_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_typedef_extraction_edge_cases\",\n  \"\
-  source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "test_typedef_extraction_edge_cases",
+    "\
+    source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_120_typedef_extr_enums.yml
+++ b/tests/unit/test_120_typedef_extr_enums.yml
@@ -5,14 +5,41 @@ test:
   id: '120'
 ---
 source_files:
-  enum_typedefs.c: "// Enum typedef declarations\ntypedef enum Color_tag {\n    COLOR_RED,\n\
-    \    COLOR_GREEN,\n    COLOR_BLUE\n} Color_t;\n\ntypedef enum log_level_tag {\n\
-    \    LOG_DEBUG,\n    LOG_INFO,\n    LOG_WARN,\n    LOG_ERROR\n} log_level_t;\n\
-    \ntypedef enum Status {\n    STATUS_OK,\n    STATUS_ERROR,\n    STATUS_PENDING\n\
-    } Status_t;\n"
+  enum_typedefs.c: |
+    // Enum typedef declarations
+    typedef enum Color_tag {
+        COLOR_RED,
+    \
+        \    COLOR_GREEN,
+        COLOR_BLUE
+    } Color_t;
+    
+    typedef enum log_level_tag {
+    \
+        \    LOG_DEBUG,
+        LOG_INFO,
+        LOG_WARN,
+        LOG_ERROR
+    } log_level_t;
+    \
+        
+    typedef enum Status {
+        STATUS_OK,
+        STATUS_ERROR,
+        STATUS_PENDING
+    \
+        } Status_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_typedef_extraction_enums\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_typedef_extraction_enums",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_120_typedef_extr_mixed.yml
+++ b/tests/unit/test_120_typedef_extr_mixed.yml
@@ -5,21 +5,69 @@ test:
   id: '120'
 ---
 source_files:
-  comprehensive_typedefs.c: "// Comprehensive typedef extraction test\n\n// Simple\
-    \ typedefs\ntypedef uint32_t MyLen;\ntypedef int32_t MyInt;\ntypedef char * MyString;\n\
-    \n// Struct typedefs\ntypedef struct MyBuffer_tag {\n    MyLen length;\n    MyString\
-    \ data;\n} MyBuffer;\n\ntypedef struct MyComplexStruct_tag {\n    MyLen id;\n\
-    \    MyString name;\n    MyCallback callback;\n    log_level_t log_level;\n} MyComplex;\n\
-    \n// Function pointer typedefs\ntypedef int (*MyCallback)(MyBuffer * buffer);\n\
-    typedef void (*log_callback_t)(log_level_t level, const char * message);\n\n//\
-    \ Pointer typedefs\ntypedef MyComplex * MyComplexPtr;\ntypedef MyComplexPtr MyComplexArray[10];\n\
-    \n// Enum typedefs\ntypedef enum Color_tag {\n    COLOR_RED,\n    COLOR_GREEN,\n\
-    \    COLOR_BLUE\n} Color_t;\n\n// Union typedefs\ntypedef union Number_tag {\n\
-    \    int i;\n    float f;\n} Number_t;\n"
+  comprehensive_typedefs.c: |
+    // Comprehensive typedef extraction test
+    
+    // Simple\
+        \ typedefs
+    typedef uint32_t MyLen;
+    typedef int32_t MyInt;
+    typedef char * MyString;
+    \
+        
+    // Struct typedefs
+    typedef struct MyBuffer_tag {
+        MyLen length;
+        MyString\
+        \ data;
+    } MyBuffer;
+    
+    typedef struct MyComplexStruct_tag {
+        MyLen id;
+    \
+        \    MyString name;
+        MyCallback callback;
+        log_level_t log_level;
+    } MyComplex;
+    \
+        
+    // Function pointer typedefs
+    typedef int (*MyCallback)(MyBuffer * buffer);
+    \
+        typedef void (*log_callback_t)(log_level_t level, const char * message);
+    
+    //\
+        \ Pointer typedefs
+    typedef MyComplex * MyComplexPtr;
+    typedef MyComplexPtr MyComplexArray[10];
+    \
+        
+    // Enum typedefs
+    typedef enum Color_tag {
+        COLOR_RED,
+        COLOR_GREEN,
+    \
+        \    COLOR_BLUE
+    } Color_t;
+    
+    // Union typedefs
+    typedef union Number_tag {
+    \
+        \    int i;
+        float f;
+    } Number_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_typedef_extraction_comprehensive\",\n\
-  \  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "test_typedef_extraction_comprehensive",
+  \
+    \  "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_120_typedef_extr_unions.yml
+++ b/tests/unit/test_120_typedef_extr_unions.yml
@@ -5,14 +5,40 @@ test:
   id: '120'
 ---
 source_files:
-  union_typedefs.c: "// Union typedef declarations\ntypedef union Number_tag {\n \
-    \   int i;\n    float f;\n    double d;\n} Number_t;\n\ntypedef union NamedUnion_tag\
-    \ {\n    char c;\n    int i;\n    short s;\n} NamedUnion_t;\n\ntypedef union Value\
-    \ {\n    int integer_value;\n    float float_value;\n    char string_value[32];\n\
-    } Value_t;\n"
+  union_typedefs.c: |
+    // Union typedef declarations
+    typedef union Number_tag {
+     \
+        \   int i;
+        float f;
+        double d;
+    } Number_t;
+    
+    typedef union NamedUnion_tag\
+        \ {
+        char c;
+        int i;
+        short s;
+    } NamedUnion_t;
+    
+    typedef union Value\
+        \ {
+        int integer_value;
+        float float_value;
+        char string_value[32];
+    \
+        } Value_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_typedef_extraction_unions\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_typedef_extraction_unions",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_122_gen_includes.yml
+++ b/tests/unit/test_122_gen_includes.yml
@@ -170,11 +170,25 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"generator_includes_and_filtering\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 3,\n  \"file_specific\": {\n    \"processor.c\": {\n      \"include_filter\"\
-  : [\"^api\\\\.h$\", \"^worker\\\\.h$\", \"^types\\\\.h$\", \"^platform\\\\.h$\"\
-  ],\n      \"include_depth\": 2\n    }\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "generator_includes_and_filtering",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 3,
+    "file_specific": {
+      "processor.c": {
+        "include_filter"\
+    : ["^api\\\\.h$", "^worker\\\\.h$", "^types\\\\.h$", "^platform\\\\.h$"\
+    ],
+        "include_depth": 2
+      }
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_123_gen_naming.yml
+++ b/tests/unit/test_123_gen_naming.yml
@@ -6,39 +6,105 @@ test:
   id: '123'
 ---
 source_files:
-  model.json: "{\n  \"project_name\": \"naming_conventions_project\",\n  \"source_folder\"\
-    : \"/tmp\",\n  \"files\": {\n    \"main.c\": {\n      \"file_path\": \"/tmp/main.c\"\
-    ,\n      \"includes\": [\"utils.h\"],\n      \"macros\": {},\n      \"enums\"\
-    : {},\n      \"structs\": {},\n      \"unions\": {},\n      \"aliases\": {},\n\
-    \      \"functions\": [{\"name\": \"main\", \"return_type\": \"int\", \"is_declaration\"\
-    : false, \"parameters\": []}],\n      \"globals\": []\n    },\n    \"utils.h\"\
-    : {\n      \"file_path\": \"/tmp/utils.h\",\n      \"includes\": [],\n      \"\
-    macros\": {},\n      \"enums\": {},\n      \"structs\": {},\n      \"unions\"\
-    : {},\n      \"aliases\": {},\n      \"functions\": [{\"name\": \"helper_function\"\
-    , \"return_type\": \"void\", \"is_declaration\": true, \"parameters\": []}],\n\
-    \      \"globals\": []\n    },\n    \"test.c\": {\n      \"file_path\": \"/tmp/test.c\"\
-    ,\n      \"includes\": [],\n      \"macros\": {},\n      \"enums\": {\n      \
-    \  \"Color\": {\"values\": [\"RED\", \"GREEN\", \"BLUE\"]},\n        \"LOG_LEVEL_T\"\
-    : {\"values\": [\"DEBUG\", \"INFO\", \"WARNING\", \"ERROR\"]},\n        \"_private\"\
-    : {\"values\": [\"OPTION1\", \"OPTION2\"]}\n      },\n      \"structs\": {\n \
-    \       \"MyBuffer\": {\"fields\": [{\"name\": \"data\", \"type\": \"char*\"},\
-    \ {\"name\": \"size\", \"type\": \"size_t\"}]},\n        \"complex_naming_test_t\"\
-    : {\"fields\": [{\"name\": \"field1\", \"type\": \"int\"}, {\"name\": \"field2\"\
-    , \"type\": \"char*\"}]},\n        \"a\": {\"fields\": [{\"name\": \"value\",\
-    \ \"type\": \"int\"}]}\n      },\n      \"unions\": {\n        \"Value\": {\"\
-    fields\": [{\"name\": \"integer\", \"type\": \"int\"}, {\"name\": \"decimal\"\
-    , \"type\": \"float\"}]},\n        \"callback_function_t\": {\"fields\": [{\"\
-    name\": \"ptr\", \"type\": \"void*\"}, {\"name\": \"value\", \"type\": \"int\"\
-    }]},\n        \"123invalid\": {\"fields\": [{\"name\": \"number\", \"type\": \"\
-    int\"}, {\"name\": \"letter\", \"type\": \"char\"}]}\n      },\n      \"aliases\"\
-    : {\n        \"Integer\": {\"original_type\": \"int\"},\n        \"pointer_to_int\"\
-    : {\"original_type\": \"int*\"},\n        \"UPPERCASE\": {\"original_type\": \"\
-    int\"}\n      },\n      \"functions\": [],\n      \"globals\": []\n    }\n  },\n\
-    \  \"include_relations\": [\n    {\"source_file\": \"main.c\", \"included_file\"\
-    : \"utils.h\", \"depth\": 1}\n  ]\n}\n"
+  model.json: |
+    {
+      "project_name": "naming_conventions_project",
+      "source_folder"\
+        : "/tmp",
+      "files": {
+        "main.c": {
+          "file_path": "/tmp/main.c"\
+        ,
+          "includes": ["utils.h"],
+          "macros": {},
+          "enums"\
+        : {},
+          "structs": {},
+          "unions": {},
+          "aliases": {},
+    \
+        \      "functions": [{"name": "main", "return_type": "int", "is_declaration"\
+        : false, "parameters": []}],
+          "globals": []
+        },
+        "utils.h"\
+        : {
+          "file_path": "/tmp/utils.h",
+          "includes": [],
+          "\
+        macros": {},
+          "enums": {},
+          "structs": {},
+          "unions"\
+        : {},
+          "aliases": {},
+          "functions": [{"name": "helper_function"\
+        , "return_type": "void", "is_declaration": true, "parameters": []}],
+    \
+        \      "globals": []
+        },
+        "test.c": {
+          "file_path": "/tmp/test.c"\
+        ,
+          "includes": [],
+          "macros": {},
+          "enums": {
+          \
+        \  "Color": {"values": ["RED", "GREEN", "BLUE"]},
+            "LOG_LEVEL_T"\
+        : {"values": ["DEBUG", "INFO", "WARNING", "ERROR"]},
+            "_private"\
+        : {"values": ["OPTION1", "OPTION2"]}
+          },
+          "structs": {
+     \
+        \       "MyBuffer": {"fields": [{"name": "data", "type": "char*"},\
+        \ {"name": "size", "type": "size_t"}]},
+            "complex_naming_test_t"\
+        : {"fields": [{"name": "field1", "type": "int"}, {"name": "field2"\
+        , "type": "char*"}]},
+            "a": {"fields": [{"name": "value",\
+        \ "type": "int"}]}
+          },
+          "unions": {
+            "Value": {"\
+        fields": [{"name": "integer", "type": "int"}, {"name": "decimal"\
+        , "type": "float"}]},
+            "callback_function_t": {"fields": [{"\
+        name": "ptr", "type": "void*"}, {"name": "value", "type": "int"\
+        }]},
+            "123invalid": {"fields": [{"name": "number", "type": "\
+        int"}, {"name": "letter", "type": "char"}]}
+          },
+          "aliases"\
+        : {
+            "Integer": {"original_type": "int"},
+            "pointer_to_int"\
+        : {"original_type": "int*"},
+            "UPPERCASE": {"original_type": "\
+        int"}
+          },
+          "functions": [],
+          "globals": []
+        }
+      },
+    \
+        \  "include_relations": [
+        {"source_file": "main.c", "included_file"\
+        : "utils.h", "depth": 1}
+      ]
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"naming_conventions_project\",\n  \"source_folders\"\
-  : [\"src\"],\n  \"output_dir\": \"output\",\n  \"recursive_search\": false\n}\n"
+config.json: |
+  {
+    "project_name": "naming_conventions_project",
+    "source_folders"\
+    : ["src"],
+    "output_dir": "output",
+    "recursive_search": false
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_125_gen_visibility.yml
+++ b/tests/unit/test_125_gen_visibility.yml
@@ -6,37 +6,58 @@ test:
   id: '125'
 ---
 source_files:
-  model.json: "{\n  \"project_name\": \"visibility_project\",\n  \"source_folder\"\
-    : \"/test\",\n  \"files\": {\n    \"math.c\": {\"file_path\": \"math.c\", \"functions\"\
-    : [{\"name\": \"calculate\", \"return_type\": \"int\", \"is_declaration\": false,\
-    \ \"parameters\": []}], \"globals\": [], \"includes\": [], \"macros\": {}, \"\
-    enums\": {}, \"structs\": {}, \"unions\": {}, \"aliases\": {}},\n    \"math.h\"\
-    : {\"file_path\": \"math.h\", \"functions\": [{\"name\": \"calculate\", \"return_type\"\
-    : \"int\", \"is_declaration\": true, \"parameters\": []}], \"globals\": [], \"\
-    includes\": [], \"macros\": {}, \"enums\": {}, \"structs\": {}, \"unions\": {},\
-    \ \"aliases\": {}},\n    \"utils.c\": {\"file_path\": \"utils.c\", \"functions\"\
-    : [{\"name\": \"internal_helper\", \"return_type\": \"void\", \"is_declaration\"\
-    : false, \"parameters\": []}], \"globals\": [], \"includes\": [], \"macros\":\
-    \ {}, \"enums\": {}, \"structs\": {}, \"unions\": {}, \"aliases\": {}},\n    \"\
-    config.c\": {\"file_path\": \"config.c\", \"functions\": [], \"globals\": [{\"\
-    name\": \"global_config\", \"type\": \"int\"}], \"includes\": [], \"macros\":\
-    \ {}, \"enums\": {}, \"structs\": {}, \"unions\": {}, \"aliases\": {}},\n    \"\
-    config.h\": {\"file_path\": \"config.h\", \"functions\": [], \"globals\": [{\"\
-    name\": \"global_config\", \"type\": \"int\"}], \"includes\": [], \"macros\":\
-    \ {}, \"enums\": {}, \"structs\": {}, \"unions\": {}, \"aliases\": {}},\n    \"\
-    internal.c\": {\"file_path\": \"internal.c\", \"functions\": [], \"globals\":\
-    \ [{\"name\": \"internal_state\", \"type\": \"static int\"}], \"includes\": [],\
-    \ \"macros\": {}, \"enums\": {}, \"structs\": {}, \"unions\": {}, \"aliases\"\
-    : {}},\n    \"standalone.c\": {\"file_path\": \"standalone.c\", \"functions\"\
-    : [{\"name\": \"function_one\", \"return_type\": \"int\", \"is_declaration\":\
-    \ false, \"parameters\": []}, {\"name\": \"function_two\", \"return_type\": \"\
-    void\", \"is_declaration\": false, \"parameters\": []}], \"globals\": [{\"name\"\
-    : \"global_one\", \"type\": \"int\"}, {\"name\": \"global_two\", \"type\": \"\
-    char*\"}], \"includes\": [], \"macros\": {}, \"enums\": {}, \"structs\": {}, \"\
-    unions\": {}, \"aliases\": {}}\n  },\n  \"include_relations\": []\n}\n"
+  model.json: |
+    {
+      "project_name": "visibility_project",
+      "source_folder"\
+        : "/test",
+      "files": {
+        "math.c": {"file_path": "math.c", "functions"\
+        : [{"name": "calculate", "return_type": "int", "is_declaration": false,\
+        \ "parameters": []}], "globals": [], "includes": [], "macros": {}, "\
+        enums": {}, "structs": {}, "unions": {}, "aliases": {}},
+        "math.h"\
+        : {"file_path": "math.h", "functions": [{"name": "calculate", "return_type"\
+        : "int", "is_declaration": true, "parameters": []}], "globals": [], "\
+        includes": [], "macros": {}, "enums": {}, "structs": {}, "unions": {},\
+        \ "aliases": {}},
+        "utils.c": {"file_path": "utils.c", "functions"\
+        : [{"name": "internal_helper", "return_type": "void", "is_declaration"\
+        : false, "parameters": []}], "globals": [], "includes": [], "macros":\
+        \ {}, "enums": {}, "structs": {}, "unions": {}, "aliases": {}},
+        "\
+        config.c": {"file_path": "config.c", "functions": [], "globals": [{"\
+        name": "global_config", "type": "int"}], "includes": [], "macros":\
+        \ {}, "enums": {}, "structs": {}, "unions": {}, "aliases": {}},
+        "\
+        config.h": {"file_path": "config.h", "functions": [], "globals": [{"\
+        name": "global_config", "type": "int"}], "includes": [], "macros":\
+        \ {}, "enums": {}, "structs": {}, "unions": {}, "aliases": {}},
+        "\
+        internal.c": {"file_path": "internal.c", "functions": [], "globals":\
+        \ [{"name": "internal_state", "type": "static int"}], "includes": [],\
+        \ "macros": {}, "enums": {}, "structs": {}, "unions": {}, "aliases"\
+        : {}},
+        "standalone.c": {"file_path": "standalone.c", "functions"\
+        : [{"name": "function_one", "return_type": "int", "is_declaration":\
+        \ false, "parameters": []}, {"name": "function_two", "return_type": "\
+        void", "is_declaration": false, "parameters": []}], "globals": [{"name"\
+        : "global_one", "type": "int"}, {"name": "global_two", "type": "\
+        char*"}], "includes": [], "macros": {}, "enums": {}, "structs": {}, "\
+        unions": {}, "aliases": {}}
+      },
+      "include_relations": []
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"visibility_project\",\n  \"output_dir\": \"\
-  output\",\n  \"source_folders\": [\"src\"]\n}\n"
+config.json: |
+  {
+    "project_name": "visibility_project",
+    "output_dir": "\
+    output",
+    "source_folders": ["src"]
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_126_parser_typedefs.yml
+++ b/tests/unit/test_126_parser_typedefs.yml
@@ -6,15 +6,47 @@ test:
   id: '126'
 ---
 source_files:
-  typedefs.c: "typedef int Integer;\ntypedef char* String;\ntypedef void (*Callback)(int);\n\
-    typedef struct {\n    int x;\n    int y;\n} Point;\n"
-  point_typedef.c: "typedef struct point_tag {\n    int x;\n    int y;\n} point_t;\n"
-  status.c: "enum Status {\n    OK = 0,\n    ERROR = 1,\n    PENDING = 2\n};\n"
-  color.c: "typedef enum {\n    RED,\n    GREEN,\n    BLUE\n} Color;\n"
+  typedefs.c: |
+    typedef int Integer;
+    typedef char* String;
+    typedef void (*Callback)(int);
+    \
+        typedef struct {
+        int x;
+        int y;
+    } Point;
+    
+  point_typedef.c: |
+    typedef struct point_tag {
+        int x;
+        int y;
+    } point_t;
+    
+  status.c: |
+    enum Status {
+        OK = 0,
+        ERROR = 1,
+        PENDING = 2
+    };
+    
+  color.c: |
+    typedef enum {
+        RED,
+        GREEN,
+        BLUE
+    } Color;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_parser_typedefs_comprehensive\",\n  \"\
-  source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "test_parser_typedefs_comprehensive",
+    "\
+    source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_127_parser_simple_c.yml
+++ b/tests/unit/test_127_parser_simple_c.yml
@@ -6,12 +6,37 @@ test:
   id: '127'
 ---
 source_files:
-  simple.c: "#include <stdio.h>\n\nstruct Person {\n    char name[50];\n    int age;\n\
-    };\n\nenum Status {\n    OK,\n    ERROR\n};\n\nint main() {\n    return 0;\n}\n\
-    \nint global_var;\n"
+  simple.c: |
+    #include <stdio.h>
+    
+    struct Person {
+        char name[50];
+        int age;
+    \
+        };
+    
+    enum Status {
+        OK,
+        ERROR
+    };
+    
+    int main() {
+        return 0;
+    }
+    \
+        
+    int global_var;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_parser_simple\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_parser_simple",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_128_parser_simple_struct.yml
+++ b/tests/unit/test_128_parser_simple_struct.yml
@@ -5,10 +5,23 @@ test:
   id: '128'
 ---
 source_files:
-  point.c: "struct Point {\n    int x;\n    int y;\n    char label[32];\n};\n"
+  point.c: |
+    struct Point {
+        int x;
+        int y;
+        char label[32];
+    };
+    
 ---
-config.json: "{\n  \"project_name\": \"test_parser_simple_struct\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_parser_simple_struct",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_129_parser_encoding.yml
+++ b/tests/unit/test_129_parser_encoding.yml
@@ -5,11 +5,21 @@ test:
   id: '129'
 ---
 source_files:
-  encoding.c: "// UTF-8 comment with \xE9mojis \U0001F680\nint main() { return 0;\
-    \ }\n"
+  encoding.c: |
+    // UTF-8 comment with \xE9mojis \U0001F680
+    int main() { return 0;\
+        \ }
+    
 ---
-config.json: "{\n  \"project_name\": \"test_parser_encoding\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_parser_encoding",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_130_parser_elems.yml
+++ b/tests/unit/test_130_parser_elems.yml
@@ -6,10 +6,31 @@ test:
   id: '130'
 ---
 source_files:
-  structs.c: "struct Point {\n    int x;\n    int y;\n};\n\nstruct Rectangle {\n \
-    \   int width;\n    int height;\n};\n"
-  enums.c: "enum Color {\n    RED,\n    GREEN,\n    BLUE\n};\n\nenum Status {\n  \
-    \  RUNNING,\n    STOPPED\n};\n"
+  structs.c: |
+    struct Point {
+        int x;
+        int y;
+    };
+    
+    struct Rectangle {
+     \
+        \   int width;
+        int height;
+    };
+    
+  enums.c: |
+    enum Color {
+        RED,
+        GREEN,
+        BLUE
+    };
+    
+    enum Status {
+      \
+        \  RUNNING,
+        STOPPED
+    };
+    
   globals.c: 'int global_int = 42;
 
     float global_float = 3.14f;
@@ -29,9 +50,16 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"test_parser_elements_comprehensive\",\n  \"\
-  source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "test_parser_elements_comprehensive",
+    "\
+    source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_131_parser_funcs.yml
+++ b/tests/unit/test_131_parser_funcs.yml
@@ -6,20 +6,53 @@ test:
   id: '131'
 ---
 source_files:
-  functions_all.c: "#include <stdarg.h>\n\n// Declarations\nint decl_add(int a, int\
-    \ b);\nvoid decl_process_point(point_t * p);\nreal_t decl_average(const int *\
-    \ arr, size_t len);\n\n// Definitions\nint def_add(int a, int b) { return a +\
-    \ b; }\ninline void def_inline_process(point_t * p) { (void)p; }\nstatic int def_static_helper(const\
-    \ char * s) { return (int)(s ? *s : 0); }\n\n// Complex params\nint callback(void\
-    \ * data, void * user_data) { return 0; }\nvoid array_func(int arr[10], size_t\
-    \ size) { (void)arr; (void)size; }\nconst char * const_func(const char * str)\
-    \ { return str; }\n\n// Empty params\nvoid init(void) {}\nvoid cleanup(void) {}\n\
-    \n// Variadic\nint log_message(int level, const char * fmt, ...) {\n  va_list\
-    \ args; va_start(args, fmt); va_end(args); (void)level; return 0;\n}\n"
+  functions_all.c: |
+    #include <stdarg.h>
+    
+    // Declarations
+    int decl_add(int a, int\
+        \ b);
+    void decl_process_point(point_t * p);
+    real_t decl_average(const int *\
+        \ arr, size_t len);
+    
+    // Definitions
+    int def_add(int a, int b) { return a +\
+        \ b; }
+    inline void def_inline_process(point_t * p) { (void)p; }
+    static int def_static_helper(const\
+        \ char * s) { return (int)(s ? *s : 0); }
+    
+    // Complex params
+    int callback(void\
+        \ * data, void * user_data) { return 0; }
+    void array_func(int arr[10], size_t\
+        \ size) { (void)arr; (void)size; }
+    const char * const_func(const char * str)\
+        \ { return str; }
+    
+    // Empty params
+    void init(void) {}
+    void cleanup(void) {}
+    \
+        
+    // Variadic
+    int log_message(int level, const char * fmt, ...) {
+      va_list\
+        \ args; va_start(args, fmt); va_end(args); (void)level; return 0;
+    }
+    
 ---
-config.json: "{\n  \"project_name\": \"parser_functions_and_parameters_comprehensive\"\
-  ,\n  \"source_folders\": [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\"\
-  : true\n}\n"
+config.json: |
+  {
+    "project_name": "parser_functions_and_parameters_comprehensive"\
+    ,
+    "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search"\
+    : true
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_132_parser_includes.yml
+++ b/tests/unit/test_132_parser_includes.yml
@@ -139,11 +139,25 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"parser_includes_comprehensive\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 3,\n  \"file_specific\": {\n    \"processor.c\": {\n      \"include_filter\"\
-  : [\"^api\\\\.h$\", \"^worker\\\\.h$\", \"^types\\\\.h$\", \"^platform\\\\.h$\"\
-  ],\n      \"include_depth\": 2\n    }\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "parser_includes_comprehensive",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 3,
+    "file_specific": {
+      "processor.c": {
+        "include_filter"\
+    : ["^api\\\\.h$", "^worker\\\\.h$", "^types\\\\.h$", "^platform\\\\.h$"\
+    ],
+        "include_depth": 2
+      }
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_133_include_filter.yml
+++ b/tests/unit/test_133_include_filter.yml
@@ -6,10 +6,25 @@ test:
   id: '133'
 ---
 source_files:
-  processor.c: "#include \"api.h\"\n#include \"worker.h\"\n#include \"private_worker.h\"\
-    \n\n// Main processor functions\nvoid process_data() {\n    api_function();\n\
-    \    worker_function();\n}\n\nint main() {\n    process_data();\n    return 0;\n\
-    }\n"
+  processor.c: |
+    #include "api.h"
+    #include "worker.h"
+    #include "private_worker.h"\
+        
+    
+    // Main processor functions
+    void process_data() {
+        api_function();
+    \
+        \    worker_function();
+    }
+    
+    int main() {
+        process_data();
+        return 0;
+    \
+        }
+    
   api.h: '#ifndef API_H
 
     #define API_H
@@ -68,8 +83,20 @@ source_files:
     #endif
 
     '
-  types.h: "#ifndef TYPES_H\n#define TYPES_H\n\n#include \"constants.h\"\n\ntypedef\
-    \ int ProcessorID;\ntypedef struct {\n    int x, y;\n} Point;\n\n#endif\n"
+  types.h: |
+    #ifndef TYPES_H
+    #define TYPES_H
+    
+    #include "constants.h"
+    
+    typedef\
+        \ int ProcessorID;
+    typedef struct {
+        int x, y;
+    } Point;
+    
+    #endif
+    
   platform.h: '#ifndef PLATFORM_H
 
     #define PLATFORM_H
@@ -107,8 +134,19 @@ source_files:
     #endif
 
     '
-  errors.h: "#ifndef ERRORS_H\n#define ERRORS_H\n\nenum ErrorCode {\n    ERROR_NONE,\n\
-    \    ERROR_INVALID,\n    ERROR_MEMORY\n};\n\n#endif\n"
+  errors.h: |
+    #ifndef ERRORS_H
+    #define ERRORS_H
+    
+    enum ErrorCode {
+        ERROR_NONE,
+    \
+        \    ERROR_INVALID,
+        ERROR_MEMORY
+    };
+    
+    #endif
+    
   constants.h: '#ifndef CONSTANTS_H
 
     #define CONSTANTS_H
@@ -134,11 +172,25 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"test_include_filtering\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 3,\n  \"file_specific\": {\n    \"processor.c\": {\n      \"include_filter\"\
-  : [\"^api\\\\.h$\", \"^worker\\\\.h$\", \"^types\\\\.h$\", \"^platform\\\\.h$\"\
-  ],\n      \"include_depth\": 2\n    }\n  }\n}\n"
+config.json: |
+  {
+    "project_name": "test_include_filtering",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 3,
+    "file_specific": {
+      "processor.c": {
+        "include_filter"\
+    : ["^api\\\\.h$", "^worker\\\\.h$", "^types\\\\.h$", "^platform\\\\.h$"\
+    ],
+        "include_depth": 2
+      }
+    }
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_134_include_proc_unit.yml
+++ b/tests/unit/test_134_include_proc_unit.yml
@@ -5,9 +5,11 @@ test:
   id: '134'
 ---
 source_files:
-  main.c: "#include \"utils.h\"\n#include <stdio.h>\n\nint main() {\n    printf(\"\
-    Hello from main\\n\");\n    int result = add_numbers(5, 3);\n    return result;\n\
-    }\n"
+  main.c: |
+    #include "utils.h"n#include <stdio.h>nnint main() {n    printf("
+        Hello from main
+    ");n    int result = add_numbers(5, 3);n    return result;n
+        }n
   utils.h: '#ifndef UTILS_H
 
     #define UTILS_H
@@ -32,9 +34,17 @@ source_files:
 
     '
 ---
-config.json: "{\n  \"project_name\": \"include_processing_basic\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true,\n  \"\
-  include_depth\": 2\n}\n"
+config.json: |
+  {
+    "project_name": "include_processing_basic",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "\
+    include_depth": 2
+  }
+  
 ---
 assertions:
   execution:

--- a/tests/unit/test_135_nested_structs.yml
+++ b/tests/unit/test_135_nested_structs.yml
@@ -5,12 +5,28 @@ test:
   id: '135'
 ---
 source_files:
-  nested_structures_puml.c: "typedef union {\n    int primary_int;\n    union {\n\
-    \        float nested_float;\n        double nested_double;\n    } nested_union;\n\
-    \    char primary_bytes[32];\n} test_union_t;\n"
+  nested_structures_puml.c: |
+    typedef union {
+        int primary_int;
+        union {
+    \
+        \        float nested_float;
+            double nested_double;
+        } nested_union;
+    \
+        \    char primary_bytes[32];
+    } test_union_t;
+    
 ---
-config.json: "{\n  \"project_name\": \"test_nested_structures_puml\",\n  \"source_folders\"\
-  : [\".\"],\n  \"output_dir\": \"./output\",\n  \"recursive_search\": true\n}\n"
+config.json: |
+  {
+    "project_name": "test_nested_structures_puml",
+    "source_folders"\
+    : ["."],
+    "output_dir": "./output",
+    "recursive_search": true
+  }
+  
 ---
 assertions:
   execution:


### PR DESCRIPTION
Reformat YAML files in `tests/` to improve readability by replacing escaped `\n` sequences with actual newlines using literal block scalars.

---
<a href="https://cursor.com/background-agent?bcId=bc-d947ccee-32e2-4e35-8d6b-56fe48270ba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d947ccee-32e2-4e35-8d6b-56fe48270ba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

