### PR TITLE
Process markdown files and update include display

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The `file_specific` feature allows you to configure file-specific settings for d
 
 Files without file-specific configuration will use the global settings. Include relationships are computed in the transformer and stored in `include_relations` on root `.c` files, which the generator consumes. The generator no longer accepts an `include_depth` parameter and falls back to direct includes only when `include_relations` are absent.
 
+- **always_show_includes** (optional, global): When set to `true`, headers filtered out by `include_filter` remain visible in the diagram as empty header classes. Their contents and further includes are not processed, but their include relationships are still drawn from the file that included them.
+
 ### Model Transformations
 
 The transformer supports modifying the parsed model before generating diagrams:

--- a/docs/puml_template.md
+++ b/docs/puml_template.md
@@ -52,6 +52,7 @@ This template defines the structure for generating PlantUML diagrams from C sour
 ### Include Relationships
 - **C files including headers**: `{C_FILE} --> {HEADER_FILE} : <<include>>`
 - **Header-to-header includes**: `{HEADER_FILE} --> {OTHER_HEADER_FILE} : <<include>>`
+- Note: When `always_show_includes` is enabled, headers filtered out by `include_filter` are still rendered as empty header classes, and the include arrows remain visible.
 
 ### Declaration Relationships
 - **Files declaring typedefs**: `{FILE} ..> {TYPEDEF} : <<declares>>`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -478,6 +478,7 @@ The system uses a JSON-based configuration file with the following parameters:
 - **`recursive_search`**: Whether to search subdirectories recursively (default: true)
 - **`include_depth`**: Depth for processing include relationships (default: 1)
 - **`file_filters`**: Regex patterns for including/excluding files
+- **`always_show_includes`**: When true, headers excluded by `include_filter` are still shown as empty header classes in diagrams, and their include relation is drawn. Their content and further includes are not processed.
 
 - **`transformations`**: Rules for model transformation and file selection
 

--- a/src/c2puml/config.py
+++ b/src/c2puml/config.py
@@ -25,6 +25,7 @@ class Config:
     recursive_search: bool = True
     include_depth: int = 1
     include_filter_local_only: bool = False
+    always_show_includes: bool = False
 
     # Generator formatting options
     max_function_signature_chars: int = 0  # 0 or less means unlimited (no truncation)
@@ -63,6 +64,8 @@ class Config:
             self.include_depth = 1
         if not hasattr(self, "include_filter_local_only"):
             self.include_filter_local_only = False
+        if not hasattr(self, "always_show_includes"):
+            self.always_show_includes = False
         if not hasattr(self, "max_function_signature_chars"):
             self.max_function_signature_chars = 0
         if not hasattr(self, "file_filters"):
@@ -177,6 +180,7 @@ class Config:
             "recursive_search": self.recursive_search,
             "include_depth": self.include_depth,
             "include_filter_local_only": self.include_filter_local_only,
+            "always_show_includes": self.always_show_includes,
             "max_function_signature_chars": self.max_function_signature_chars,
             "file_filters": self.file_filters,
             "file_specific": self.file_specific,
@@ -235,6 +239,7 @@ class Config:
             and self.recursive_search == other.recursive_search
             and self.include_depth == other.include_depth
             and self.include_filter_local_only == other.include_filter_local_only
+            and self.always_show_includes == other.always_show_includes
             and self.file_filters == other.file_filters
             and self.file_specific == other.file_specific
             and self.transformations == other.transformations

--- a/src/c2puml/models.py
+++ b/src/c2puml/models.py
@@ -189,7 +189,7 @@ class FileModel:
     unions: Dict[str, Union] = field(default_factory=dict)
     include_relations: List[IncludeRelation] = field(default_factory=list)
     anonymous_relationships: Dict[str, List[str]] = field(default_factory=dict)  # parent -> [child1, child2, ...]
-
+    placeholder_headers: Set[str] = field(default_factory=set)  # Headers shown as empty (placeholders) in diagrams
     def __post_init__(self):
         """Extract filename from file_path if not provided"""
         if not self.name:
@@ -203,6 +203,8 @@ class FileModel:
 
         # Convert set to list for JSON serialization and sort for consistency
         data["includes"] = sorted(list(self.includes))
+        # Serialize placeholder headers as sorted list
+        data["placeholder_headers"] = sorted(list(self.placeholder_headers))
         # Convert include_relations to list of dicts and sort for consistency
         data["include_relations"] = sorted(
             [asdict(rel) for rel in self.include_relations],
@@ -340,6 +342,8 @@ class FileModel:
         new_data["unions"] = unions
         new_data["aliases"] = aliases
         new_data["include_relations"] = include_relations
+        # Load placeholder headers (if present)
+        new_data["placeholder_headers"] = set(data.get("placeholder_headers", []))
 
         return cls(**new_data)
 


### PR DESCRIPTION
Adds `always_show_includes` configuration to display filtered headers as empty classes with their include relations in PlantUML diagrams.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfc93cd4-73bb-4f06-9d25-5f6d2e054c6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfc93cd4-73bb-4f06-9d25-5f6d2e054c6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

