### PR TITLE
Clean up and organize markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,85 +128,25 @@ The scripts automatically:
 
 ## Configuration
 
-Create `config.json` for customization. The configuration supports multiple filtering and transformation options:
-
-### Filtering Options
-
-- **file_filters**: Filter files by path patterns
-
-- **file_specific**: Configure file-specific settings including include filters for each root C file
-
-### File-Specific Configuration
-
-The `file_specific` feature allows you to configure file-specific settings for different root `.c` files. Each file can have its own `include_filter` and can override the global `include_depth` used by the transformer:
-
-```json
-"file_specific": {
-  "main.c": {
-    "include_filter": ["^stdio\\.h$", "^stdlib\\.h$", "^string\\.h$"],
-    "include_depth": 3
-  },
-  "network.c": {
-    "include_filter": ["^sys/socket\\.h$", "^netinet/", "^arpa/"],
-    "include_depth": 2
-  },
-  "database.c": {
-    "include_filter": ["^sqlite3\\.h$", "^mysql\\.h$", "^postgresql/"],
-    "include_depth": 4
-  },
-  "simple.c": {
-    "include_depth": 1
-  }
-}
-```
-
-**Available file-specific settings:**
-- **include_filter** (optional): Array of regex patterns to filter includes for this specific file
-- **include_depth** (optional): Override the global include_depth setting for this specific file (applied by transformer)
-
-Files without file-specific configuration will use the global settings. Include relationships are computed in the transformer and stored in `include_relations` on root `.c` files, which the generator consumes. The generator no longer accepts an `include_depth` parameter and falls back to direct includes only when `include_relations` are absent.
-
-- **always_show_includes** (optional, global): When set to `true`, headers filtered out by `include_filter` remain visible in the diagram as empty header classes. Their contents and further includes are not processed, but their include relationships are still drawn from the file that included them.
-
-### Model Transformations
-
-The transformer supports modifying the parsed model before generating diagrams. Transformations are fully implemented and support multi-stage, containerized configuration with deterministic ordering (alphabetical by container name).
-
-Recommended containerized configuration (use numeric prefixes to control order):
+Create a `config.json` to customize analysis and output. Minimal example:
 
 ```json
 {
-  "transformations_01_rename": {
-    "file_selection": [".*main\\.c$"],
-    "rename": {
-      "typedef": {"^old_name$": "new_name"},
-      "functions": {"^calculate$": "compute"},
-      "macros": {"^OLD_MACRO$": "NEW_MACRO"},
-      "globals": {"^old_var$": "new_var"},
-      "includes": {"^old\\.h$": "new\\.h"},
-      "files": {"^legacy\\.c$": "modern\\.c"}
-    }
-  },
-  "transformations_02_cleanup": {
-    "file_selection": [],
-    "remove": {
-      "typedef": ["^legacy_.*"],
-      "functions": ["^debug_.*", "^internal_.*"],
-      "macros": ["^DEBUG_.*", "^TEMP_.*"],
-      "globals": ["^old_global$"],
-      "includes": ["^deprecated\\.h$"]
-    }
-  }
+  "project_name": "my_project",
+  "source_folders": ["./src"],
+  "output_dir": "./output"
 }
 ```
 
-Notes:
-- Containers are discovered by keys starting with `transformations` and applied in alphabetical order.
-- `file_selection` is a list of regex patterns matched against file paths; omitted or empty applies to all files.
-- Typedef renames automatically update type references in functions, globals, structs, and unions.
-- Removing typedefs cleans up type references across the model.
-- Include/file renames propagate to `includes` and `include_relations`.
-- `add` is reserved for future use.
+Run with a config file:
+
+```bash
+c2puml --config config.json
+# or (merges all .json files in the current directory)
+c2puml
+```
+
+For full examples (file-specific include filters, include depth, formatting, and the transformation system), see the Configuration Guide: [docs/configuration.md](docs/configuration.md).
 
 ## Generated Output
 
@@ -218,92 +158,9 @@ The tool creates PlantUML diagrams showing:
 - Color-coded elements (source, headers, typedefs)
 - Dynamic visibility detection (public/private based on header presence)
 
-## Architecture
+## Development
 
-**3-step processing pipeline with modular core components:**
-
-1. **Parse** - Advanced C/C++ parsing with tokenization → `model.json`
-2. **Transform** - Model transformation based on configuration → `model_transformed.json`  
-3. **Generate** - PlantUML diagram generation with proper UML notation
-
-### Core Components
-
-- **Parser (`core/parser.py`)** - Main parsing orchestration with CParser implementation
-- **Tokenizer (`core/parser_tokenizer.py`)** - Advanced C/C++ tokenization and lexical analysis
-- **Preprocessor (`core/preprocessor.py`)** - Handles conditional compilation and preprocessor directives
-- **Transformer (`core/transformer.py`)** - Model transformation and filtering engine
-- **Generator (`core/generator.py`)** - PlantUML diagram generation with proper formatting
-- **Verifier (`core/verifier.py`)** - Model validation and sanity checking
-
-## Development Setup
-
-### Manual Setup
-
-```bash
-# Create virtual environment
-python3 -m venv venv
-
-# Activate virtual environment
-source venv/bin/activate  # Linux/macOS
-# or
-venv\Scripts\activate     # Windows
-
-# Install development dependencies
-pip install -r requirements-dev.txt
-
-# Install package in development mode
-pip install -e .
-```
-
-### VSCode Configuration
-
-**VSCode Tasks**: The project includes pre-configured tasks accessible via `Ctrl+Shift+P` → "Tasks: Run Task":
-- **Run Full Workflow** - Complete analysis and diagram generation (parse → transform → generate)
-- **Run Example** - Quick test with example files and comprehensive verification
-- **Generate Pictures** - Convert PlantUML to PNG images with PlantUML toolchain
-- **Run Tests** - Execute comprehensive test suite with coverage reporting
-- **Install Dependencies** - Set up development environment with all required packages
-- **Format & Lint** - Code quality checks with Black, isort, and flake8
-
-### Development Commands
-
-```bash
-# Run all tests
-./scripts/run_all_tests.sh     # Linux/macOS
-scripts/run_all_tests.bat      # Windows
-python scripts/run_all_tests.py # Cross-platform
-
-# Run tests with coverage
-./scripts/run_tests_with_coverage.sh # Linux/macOS (comprehensive coverage)
-
-# Format and lint code
-scripts/format_lint.bat        # Windows
-
-# Generate PNG images from PlantUML
-./scripts/picgen.sh            # Linux/macOS (comprehensive PlantUML toolchain)
-scripts/picgen.bat             # Windows
-
-# Run full workflow (parse → transform → generate)
-./scripts/run_all.sh           # Linux/macOS
-scripts/run_all.bat            # Windows
-
-# Run example workflow
-./scripts/run_example.sh       # Linux/macOS
-scripts/run_example.bat        # Windows
-# Or use standalone script directly:
-python3 main.py --config tests/example/config.json
-
-# Install dependencies
-scripts/install_dependencies.bat # Windows
-
-# Git management utilities
-scripts/git_manage.bat         # Windows - Interactive git operations
-scripts/git_reset_pull.bat     # Windows - Reset and pull from remote
-
-# Debug and development utilities
-python scripts/debug.py        # Development debugging script
-python scripts/run_example_with_coverage.py # Example with coverage
-```
+For architecture, component internals, and testing details, see docs/specification.md and tests/README.md.
 
 ## Troubleshooting
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,64 @@ Run:
 c2puml --config config.json
 ```
 
+## Examples
+
+### Full configuration example
+```json
+{
+  "project_name": "Example",
+  "source_folders": ["tests/example/source"],
+  "output_dir": "./output",
+  "model_output_path": "model.json",
+  "recursive_search": true,
+  "include_depth": 2,
+  "include_filter_local_only": false,
+  "always_show_includes": true,
+  "convert_empty_class_to_artifact": false,
+  "max_function_signature_chars": 0,
+  "hide_macro_values": false,
+  "file_filters": {
+    "include": [".*\\.(c|h)$"],
+    "exclude": [".*test.*"]
+  },
+  "file_specific": {
+    "main.c": {
+      "include_filter": ["^stdio\\.h$", "^stdlib\\.h$", "^string\\.h$"],
+      "include_depth": 3
+    }
+  },
+  "transformations_01_rename": {
+    "file_selection": [".*main\\.c$"],
+    "rename": {
+      "typedef": {"^old_config_t$": "config_t"},
+      "functions": {"^calculate$": "compute"},
+      "files": {"^old_impl\\.c$": "new_impl\\.c"}
+    }
+  },
+  "transformations_02_cleanup": {
+    "file_selection": [],
+    "remove": {
+      "typedef": ["^obsolete_.*"],
+      "functions": ["^debug_.*"],
+      "macros": ["^DEBUG_.*"],
+      "includes": ["^old_header\\.h$"]
+    }
+  }
+}
+```
+
+### File-specific include filtering and depth override
+```json
+{
+  "file_specific": {
+    "network.c": {
+      "include_filter": ["^sys/socket\\.h$", "^netinet/", "^arpa/"],
+      "include_depth": 2
+    }
+  }
+}
+```
+
 ## Core Parameters
 
 - **project_name** (string, default: "Unknown_Project")
@@ -125,66 +183,8 @@ The transformer supports a multi-stage, containerized configuration. Containers 
 - `include_filter_local_only`: augments per-file include filters to prefer the matching local header (e.g., `^main\\.h$`).
 - `always_show_includes`: when true, headers excluded by filters are still rendered as placeholders with arrows, without content expansion.
 
-
-
-## Examples
-
-### Full configuration example
-```json
-{
-  "project_name": "Example",
-  "source_folders": ["tests/example/source"],
-  "output_dir": "./output",
-  "model_output_path": "model.json",
-  "recursive_search": true,
-  "include_depth": 2,
-  "include_filter_local_only": false,
-  "always_show_includes": true,
-  "convert_empty_class_to_artifact": false,
-  "max_function_signature_chars": 0,
-  "hide_macro_values": false,
-  "file_filters": {
-    "include": [".*\\.(c|h)$"],
-    "exclude": [".*test.*"]
-  },
-  "file_specific": {
-    "main.c": {
-      "include_filter": ["^stdio\\.h$", "^stdlib\\.h$", "^string\\.h$"],
-      "include_depth": 3
-    }
-  },
-  "transformations_01_rename": {
-    "file_selection": [".*main\\.c$"],
-    "rename": {
-      "typedef": {"^old_config_t$": "config_t"},
-      "functions": {"^calculate$": "compute"},
-      "files": {"^old_impl\\.c$": "new_impl\\.c"}
-    }
-  },
-  "transformations_02_cleanup": {
-    "file_selection": [],
-    "remove": {
-      "typedef": ["^obsolete_.*"],
-      "functions": ["^debug_.*"],
-      "macros": ["^DEBUG_.*"],
-      "includes": ["^old_header\\.h$"]
-    }
-  }
-}
-```
-
-### File-specific include filtering and depth override
-```json
-{
-  "file_specific": {
-    "network.c": {
-      "include_filter": ["^sys/socket\\.h$", "^netinet/", "^arpa/"],
-      "include_depth": 2
-    }
-  }
-}
-```
+ 
 
 ## See also
-- Specification: `docs/specification.md`
-- PlantUML Template: `docs/puml_template.md`
+- [Specification](specification.md)
+- [PlantUML Template](puml_template.md)

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,12 +1,8 @@
-# C to PlantUML Converter - Component Specification
+# C to PlantUML Converter - Technical Specification
 
-**Current Implementation Status**: ✅ **FULLY IMPLEMENTED AND VERIFIED**  
-**Last Updated**: August 2025  
-**Version**: 3.1.0 (Production Ready with Advanced Tokenization and Transformation)
+This document is for developers and testers. For installation, CLI usage, and configuration walkthroughs, see [README](../README.md) and the [Configuration Guide](configuration.md).
 
-This specification reflects the current implementation with all features fully functional and tested, including advanced tokenization, preprocessor handling, model verification capabilities, and comprehensive transformation system. All functionality has been verified through extensive testing with 376 unit tests and integration tests passing.
-
-## 1. High-Level Functional Specification
+## 1. Functional Overview
 
 The C to PlantUML Converter is a Python-based tool that analyzes C/C++ source code projects and generates comprehensive PlantUML class diagrams. The system provides a complete workflow from source code parsing to structured diagram generation with advanced filtering and transformation capabilities, powered by robust tokenization and preprocessor handling.
 
@@ -122,50 +118,26 @@ The system supports C/C++ file formats and language features:
 - **Include Directives**: `#include` with angle brackets and quotes
 
 ### Configuration Examples
-Functional configuration examples for common use cases:
+For end‑user configuration examples, refer to docs/configuration.md. Below are concise developer‑focused snippets demonstrating structure only.
 
-#### File-Specific Configuration
+File‑specific configuration (structure):
 ```json
 {
   "file_specific": {
-    "sample.c": {
-      "include_filter": ["^stdio\\.h$", "^stdlib\\.h$", "^sample\\.h$"],
-      "include_depth": 3
-    },
-    "utils.c": {
-      "include_filter": ["^math\\.h$", "^time\\.h$"],
-      "include_depth": 2
-    }
+    "sample.c": { "include_filter": ["..."], "include_depth": 3 }
   }
 }
 ```
 
-#### Transformation Configuration
+Transformation containers (structure):
 ```json
 {
-  "transformations_01_rename": {
-    "file_selection": [".*transformed\\.(c|h)$"],
-    "rename": {
-      "typedef": {
-        "^old_config_t$": "config_t"
-      },
-      "functions": {
-        "^deprecated_(.*)": "legacy_\\1"
-      }
-    }
-  },
-  "transformations_02_cleanup": {
-    "file_selection": [".*transformed\\.(c|h)$"],
-    "remove": {
-      "typedef": ["^legacy_.*", "^old_.*"],
-      "functions": ["^test_.*", "^debug_.*"],
-      "macros": ["^DEPRECATED_.*", "^LEGACY_.*"]
-    }
-  }
+  "transformations_01_rename": { "file_selection": ["..."], "rename": { /* ... */ } },
+  "transformations_02_cleanup": { "file_selection": [], "remove": { /* ... */ } }
 }
 ```
 
-## 2. High-Level Requirements
+## 2. Requirements
 
 ### 2.1 Core Requirements
 - **R1**: Parse C/C++ source files and extract structural information (structs, enums, unions, functions, macros, globals, typedefs)
@@ -429,7 +401,7 @@ class Union:
     fields: List[Field]
 ```
 
-### 3.4 Configuration Parameters
+### 3.4 Configuration Parameters (reference)
 
 #### 3.4.1 Core Configuration
 The system uses a JSON-based configuration file with the following parameters:


### PR DESCRIPTION
Refactor documentation to separate end-user guides from technical specifications and reorganize configuration details.

---
<a href="https://cursor.com/background-agent?bcId=bc-4301fe9b-18f6-43c1-981f-a096ba51a46e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4301fe9b-18f6-43c1-981f-a096ba51a46e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

