### PR TITLE
Clean up and organize markdown documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,118 +18,77 @@ Run:
 c2puml --config config.json
 ```
 
-## Core Parameters
+## Configuration Examples
 
-- **project_name** (string, default: "Unknown_Project")
-  - Human-readable project name used in metadata.
-
-- **source_folders** (string[], required)
-  - One or more folders to scan for C/C++ files.
-  - Relative paths are resolved from the working directory; absolute paths supported.
-
-- **output_dir** (string, default: "./output")
-  - Directory where `model.json`, `model_transformed.json`, and `.puml` files are written.
-
-- **model_output_path** (string, default: "model.json")
-  - Filename for the parser’s model output inside `output_dir`.
-
-- **recursive_search** (boolean, default: true)
-  - Recursively discover files in `source_folders`.
-
-- **include_depth** (integer, default: 1)
-  - Controls include relationship processing depth. Applied by the transformer; results stored as `include_relations` on root `.c` files and consumed by the generator.
-  - 1: only direct includes. 2+: transitive includes and header-to-header arrows.
-
-- **include_filter_local_only** (boolean, default: false)
-  - When true, automatically adds a filter to prefer the local header matching each root C file name (e.g., `main.c` → `^main\\.h$`).
-
-- **always_show_includes** (boolean, default: false)
-  - When filtering excludes a header, still render it as an empty placeholder class and draw the include arrow. Its content and further includes are not processed.
-
-- **convert_empty_class_to_artifact** (boolean, default: false)
-  - PlantUML generation option: convert empty classes to artifacts for cleaner diagrams.
-
-### Formatting Options (Generator)
-
-- **max_function_signature_chars** (integer, default: 0)
-  - 0 or less disables truncation. If > 0, long function signatures are truncated with `...` for readability.
-
-- **hide_macro_values** (boolean, default: false)
-  - Controls simple macro value display.
-  - Function-like macros always hide definitions and show only the signature (`#define MIN(a, b)`).
-
-## File and Element Filtering
-
-- **file_filters** (object, default: `{}`)
-  - `include`: string[] of regex patterns to include file paths.
-  - `exclude`: string[] of regex patterns to exclude file paths.
-  - Applied by the transformer to filter entire files in the model.
-
-- **file_specific** (object, default: `{}`)
-  - Per-root C-file settings by basename (e.g., `"main.c"`).
-  - Keys:
-    - `include_filter` (string[]): regex patterns controlling which headers are considered for this root.
-    - `include_depth` (integer): overrides global `include_depth` for this root.
-
-Behavior:
-- Transformer processes include relations per root C file using a breadth-first, depth-limited traversal.
-- If `always_show_includes` is true, filtered-out headers appear as placeholders and are not expanded further.
-
-## Transformer Configuration (Step 2)
-
-The transformer supports a multi-stage, containerized configuration. Containers are discovered by keys that start with `transformations` and are applied in alphabetical order. Use numeric prefixes to make the order explicit.
-
-### Container structure
-
+### Basic Configuration
 ```json
 {
-  "transformations_01_rename": {
-    "file_selection": [".*main\\.c$"],
-    "rename": { /* ... */ }
-  },
-  "transformations_02_cleanup": {
-    "file_selection": [],
-    "remove": { /* ... */ }
+  "project_name": "my_project",
+  "source_folders": ["./src"],
+  "output_dir": "./output",
+  "recursive_search": true,
+  "include_depth": 2
+}
+```
+
+### File-Specific Include Filtering and Depth Override
+```json
+{
+  "project_name": "Example",
+  "source_folders": ["tests/example/source"],
+  "output_dir": "./output",
+  "recursive_search": true,
+  "include_depth": 2,
+  "file_specific": {
+    "main.c": {
+      "include_filter": ["^stdio\\.h$", "^stdlib\\.h$", "^string\\.h$"],
+      "include_depth": 3
+    },
+    "network.c": {
+      "include_filter": ["^sys/socket\\.h$", "^netinet/", "^arpa/"],
+      "include_depth": 2
+    },
+    "database.c": {
+      "include_filter": ["^sqlite3\\.h$", "^mysql\\.h$", "^postgresql/"],
+      "include_depth": 4
+    }
   }
 }
 ```
 
-- **file_selection** (string[] of regex) – optional
-  - Patterns are matched against file paths in the model. Empty or omitted applies to all files.
-  - If an invalid type is provided (e.g., object), the transformer will ignore it and apply to all files.
+### Transformation Configuration
+```json
+{
+  "project_name": "Example",
+  "source_folders": ["tests/example/source"],
+  "output_dir": "./output",
+  "recursive_search": true,
+  "include_depth": 2,
+  "transformations_01_rename": {
+    "file_selection": [".*main\\.c$"],
+    "rename": {
+      "typedef": {"^old_config_t$": "config_t"},
+      "functions": {"^calculate$": "compute"},
+      "macros": {"^OLD_MACRO$": "NEW_MACRO"},
+      "globals": {"^old_var$": "new_var"},
+      "includes": {"^old\\.h$": "new\\.h"},
+      "files": {"^old_impl\\.c$": "new_impl\\.c"}
+    }
+  },
+  "transformations_02_cleanup": {
+    "file_selection": [],
+    "remove": {
+      "typedef": ["^obsolete_.*", "^legacy_.*"],
+      "functions": ["^test_.*", "^debug_.*", "^internal_.*"],
+      "macros": ["^DEBUG_.*", "^TEMP_.*", "^DEPRECATED_.*"],
+      "globals": ["^old_global$"],
+      "includes": ["^old_header\\.h$"]
+    }
+  }
+}
+```
 
-- **rename** (object)
-  - Keys and behaviors (regex-based; deduplicates by final name):
-    - `typedef`: `{ pattern: replacement }`
-      - Also updates all type references (functions, globals, struct fields, union fields) to the new typedef name.
-    - `functions`: `{ pattern: replacement }`
-    - `macros`: `{ pattern: replacement }` (renames macro identifiers while preserving parameters and values)
-    - `globals`: `{ pattern: replacement }`
-    - `includes`: `{ pattern: replacement }` (propagates to `include_relations`)
-    - `files`: `{ pattern: replacement }` (renames file paths; propagates to `includes` and `include_relations` across the model)
-    - `structs`, `enums`, `unions`: `{ pattern: replacement }`
-
-- **remove** (object)
-  - Keys and behaviors (regex arrays):
-    - `typedef`: `[pattern, ...]` (removes typedefs; transformer cleans up any references to removed typedefs by replacing occurrences in types with `void` and normalizing spacing)
-    - `functions`, `macros`, `globals`: `[pattern, ...]`
-    - `includes`: `[pattern, ...]` (also removes matching `include_relations`)
-    - `structs`, `enums`, `unions`: `[pattern, ...]`
-
-- **add** (object)
-  - Reserved for future use (no-ops in the current implementation).
-
-### Include-depth processing in the transformer
-
-- Global `include_depth` is honored; per-file overrides via `file_specific["<root.c>"]`. Include relations are recomputed and stored as a flat list on the root C file.
-- `include_filter_local_only`: augments per-file include filters to prefer the matching local header (e.g., `^main\\.h$`).
-- `always_show_includes`: when true, headers excluded by filters are still rendered as placeholders with arrows, without content expansion.
-
-
-
-## Examples
-
-### Full configuration example
+### Full Configuration Example
 ```json
 {
   "project_name": "Example",
@@ -173,18 +132,116 @@ The transformer supports a multi-stage, containerized configuration. Containers 
 }
 ```
 
-### File-specific include filtering and depth override
+## Configuration Parameters
+
+### Core Parameters
+
+- **project_name** (string, default: "Unknown_Project")
+  - Human-readable project name used in metadata.
+
+- **source_folders** (string[], required)
+  - One or more folders to scan for C/C++ files.
+  - Relative paths are resolved from the working directory; absolute paths supported.
+
+- **output_dir** (string, default: "./output")
+  - Directory where `model.json`, `model_transformed.json`, and `.puml` files are written.
+
+- **model_output_path** (string, default: "model.json")
+  - Filename for the parser's model output inside `output_dir`.
+
+- **recursive_search** (boolean, default: true)
+  - Recursively discover files in `source_folders`.
+
+- **include_depth** (integer, default: 1)
+  - Controls include relationship processing depth. Applied by the transformer; results stored as `include_relations` on root `.c` files and consumed by the generator.
+  - 1: only direct includes. 2+: transitive includes and header-to-header arrows.
+
+- **include_filter_local_only** (boolean, default: false)
+  - When true, automatically adds a filter to prefer the local header matching each root C file name (e.g., `main.c` → `^main\\.h$`).
+
+- **always_show_includes** (boolean, default: false)
+  - When filtering excludes a header, still render it as an empty placeholder class and draw the include arrow. Its content and further includes are not processed.
+
+- **convert_empty_class_to_artifact** (boolean, default: false)
+  - PlantUML generation option: convert empty classes to artifacts for cleaner diagrams.
+
+### Formatting Options (Generator)
+
+- **max_function_signature_chars** (integer, default: 0)
+  - 0 or less disables truncation. If > 0, long function signatures are truncated with `...` for readability.
+
+- **hide_macro_values** (boolean, default: false)
+  - Controls simple macro value display.
+  - Function-like macros always hide definitions and show only the signature (`#define MIN(a, b)`).
+
+### File and Element Filtering
+
+- **file_filters** (object, default: `{}`)
+  - `include`: string[] of regex patterns to include file paths.
+  - `exclude`: string[] of regex patterns to exclude file paths.
+  - Applied by the transformer to filter entire files in the model.
+
+- **file_specific** (object, default: `{}`)
+  - Per-root C-file settings by basename (e.g., `"main.c"`).
+  - Keys:
+    - `include_filter` (string[]): regex patterns controlling which headers are considered for this root.
+    - `include_depth` (integer): overrides global `include_depth` for this root.
+
+Behavior:
+- Transformer processes include relations per root C file using a breadth-first, depth-limited traversal.
+- If `always_show_includes` is true, filtered-out headers appear as placeholders and are not expanded further.
+
+## Transformer Configuration (Step 2)
+
+The transformer supports a multi-stage, containerized configuration. Containers are discovered by keys that start with `transformations` and are applied in alphabetical order. Use numeric prefixes to make the order explicit.
+
+### Container Structure
+
 ```json
 {
-  "file_specific": {
-    "network.c": {
-      "include_filter": ["^sys/socket\\.h$", "^netinet/", "^arpa/"],
-      "include_depth": 2
-    }
+  "transformations_01_rename": {
+    "file_selection": [".*main\\.c$"],
+    "rename": { /* ... */ }
+  },
+  "transformations_02_cleanup": {
+    "file_selection": [],
+    "remove": { /* ... */ }
   }
 }
 ```
 
-## See also
-- Specification: `docs/specification.md`
-- PlantUML Template: `docs/puml_template.md`
+- **file_selection** (string[] of regex) – optional
+  - Patterns are matched against file paths in the model. Empty or omitted applies to all files.
+  - If an invalid type is provided (e.g., object), the transformer will ignore it and apply to all files.
+
+- **rename** (object)
+  - Keys and behaviors (regex-based; deduplicates by final name):
+    - `typedef`: `{ pattern: replacement }`
+      - Also updates all type references (functions, globals, struct fields, union fields) to the new typedef name.
+    - `functions`: `{ pattern: replacement }`
+    - `macros`: `{ pattern: replacement }` (renames macro identifiers while preserving parameters and values)
+    - `globals`: `{ pattern: replacement }`
+    - `includes`: `{ pattern: replacement }` (propagates to `include_relations`)
+    - `files`: `{ pattern: replacement }` (renames file paths; propagates to `includes` and `include_relations` across the model)
+    - `structs`, `enums`, `unions`: `{ pattern: replacement }`
+
+- **remove** (object)
+  - Keys and behaviors (regex arrays):
+    - `typedef`: `[pattern, ...]` (removes typedefs; transformer cleans up any references to removed typedefs by replacing occurrences in types with `void` and normalizing spacing)
+    - `functions`, `macros`, `globals`: `[pattern, ...]`
+    - `includes`: `[pattern, ...]` (also removes matching `include_relations`)
+    - `structs`, `enums`, `unions`: `[pattern, ...]`
+
+- **add** (object)
+  - Reserved for future use (no-ops in the current implementation).
+
+### Include-Depth Processing in the Transformer
+
+- Global `include_depth` is honored; per-file overrides via `file_specific["<root.c>"]`. Include relations are recomputed and stored as a flat list on the root C file.
+- `include_filter_local_only`: augments per-file include filters to prefer the matching local header (e.g., `^main\\.h$`).
+- `always_show_includes`: when true, headers excluded by filters are still rendered as placeholders with arrows, without content expansion.
+
+## See Also
+
+- [Specification](specification.md) - Technical details for developers and testers
+- [PlantUML Template](puml_template.md) - PlantUML formatting template and diagram structure rules

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -25,7 +25,6 @@ The C to PlantUML Converter is a Python-based tool that analyzes C/C++ source co
 - **Model Transformation**: Multi-stage renaming, filtering, and addition of elements using configuration-driven rules
 - **File Selection for Transformations**: Apply transformations to all files or selected ones with regex patterns
 
-
 ### Transformation System
 The system includes a comprehensive transformation pipeline that allows for sophisticated code model manipulation:
 
@@ -55,7 +54,6 @@ The system includes a comprehensive transformation pipeline that allows for soph
 
 #### Transformation Pipeline
 - **Multi-Stage Processing**: Support for multiple transformation containers applied in order
-
 - **Validation**: Comprehensive validation of transformation patterns and results
 - **Logging**: Detailed logging of transformation operations for debugging
 
@@ -121,50 +119,6 @@ The system supports C/C++ file formats and language features:
 - **Macro Definitions**: `#define`, `#undef`
 - **Include Directives**: `#include` with angle brackets and quotes
 
-### Configuration Examples
-Functional configuration examples for common use cases:
-
-#### File-Specific Configuration
-```json
-{
-  "file_specific": {
-    "sample.c": {
-      "include_filter": ["^stdio\\.h$", "^stdlib\\.h$", "^sample\\.h$"],
-      "include_depth": 3
-    },
-    "utils.c": {
-      "include_filter": ["^math\\.h$", "^time\\.h$"],
-      "include_depth": 2
-    }
-  }
-}
-```
-
-#### Transformation Configuration
-```json
-{
-  "transformations_01_rename": {
-    "file_selection": [".*transformed\\.(c|h)$"],
-    "rename": {
-      "typedef": {
-        "^old_config_t$": "config_t"
-      },
-      "functions": {
-        "^deprecated_(.*)": "legacy_\\1"
-      }
-    }
-  },
-  "transformations_02_cleanup": {
-    "file_selection": [".*transformed\\.(c|h)$"],
-    "remove": {
-      "typedef": ["^legacy_.*", "^old_.*"],
-      "functions": ["^test_.*", "^debug_.*"],
-      "macros": ["^DEPRECATED_.*", "^LEGACY_.*"]
-    }
-  }
-}
-```
-
 ## 2. High-Level Requirements
 
 ### 2.1 Core Requirements
@@ -181,7 +135,6 @@ Functional configuration examples for common use cases:
 - **R9**: Support regex-based filtering of files and code elements
 - **R10**: Enable model transformation with renaming and element addition capabilities
 - **R11**: Support multi-configuration file loading and merging
-
 - **R13**: Provide robust error handling
 - **R14**: Parse and visualize unions with their fields
 - **R15**: Handle typedefs for struct/enum/union (named and anonymous) with content display
@@ -587,7 +540,7 @@ The PlantUML formatting template and all diagram structure rules are now maintai
 - **Source/Header files**: Show only primitive typedef declarations (e.g., `typedef int MyInt`, `typedef char* String`) - struct/enum/union typedefs are NOT shown in file/header classes
 - **Typedef classes**: Show the actual content:
   - **Struct typedefs**: Show struct field names and types (e.g., `+ int x`, `+ char* name`)
-  - **Enum typedefs**: Show enum value names (e.g., `+ LOG_DEBUG`, `+ LOG_INFO`, `+ STATE_IDLE`, `+ STATE_RUNNING`)
+  - **Enum typedefs**: Show enum value names (e.g., `LOG_DEBUG`, `LOG_INFO`, `STATE_IDLE`, `STATE_RUNNING`)
   - **Union typedefs**: Show union field names and types (e.g., `+ int i`, `+ float f`)
   - **Primitive typedefs**: Show the original type name (e.g., `+ uint32_t`, `+ char*`)
 
@@ -794,8 +747,6 @@ Configuration (in `config.json`):
 
 Example behavior:
 - With `max_function_signature_chars: 60`, a signature like `+ int process_with_callbacks(int[] data, int size, math_operation_t[] operations, int op_count, void (* pre_process)(int*, int), void (* post_process)(int*, int))` may become `+ int process_with_callbacks(int[] data, int size, math_operation_t[] operations, ...)` depending on the exact threshold.
-
-
 
 #### 5.5.6 Macro Value Display (Configurable)
 


### PR DESCRIPTION
Refactor and clean up documentation files (`README.md`, `docs/specification.md`, `docs/configuration.md`) to remove duplication and organize content for specific audiences.

---
<a href="https://cursor.com/background-agent?bcId=bc-315530c0-015f-4c88-80cd-acf1ff55661a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-315530c0-015f-4c88-80cd-acf1ff55661a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

