### PR TITLE
Create pypi release workflow

### DIFF
--- a/.github/workflows/11-pypi.yml
+++ b/.github/workflows/11-pypi.yml
@@ -19,16 +19,24 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: "11.03 Prepare build environment"
+      - name: "11.03 Download release tarball"
         run: |
-          rm -rf dist build *.egg-info || true
+          mkdir -p release_src
+          curl -L -o release.tar.gz https://github.com/fischerjooo/c2puml/archive/refs/heads/release.tar.gz
+          tar -xzf release.tar.gz -C release_src --strip-components=1
+          echo "📁 Extracted contents:"
+          ls -la release_src
+          echo "📁 Extracted src/:"
+          ls -la release_src/src || true
 
       - name: "11.04 Install build tools"
         run: |
           python -m pip install --upgrade build
 
       - name: "11.05 Build distributions"
+        working-directory: release_src
         run: |
+          rm -rf dist build *.egg-info || true
           python -m build
 
       - name: "11.06 Install Twine"
@@ -36,6 +44,7 @@ jobs:
           python -m pip install --upgrade twine
 
       - name: "11.07 Upload to PyPI"
+        working-directory: release_src
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Add a GitHub Actions workflow to build and publish Python packages to PyPI using Twine and a secret token.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f7c19b7-1862-4be2-a3b1-d268b18719a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f7c19b7-1862-4be2-a3b1-d268b18719a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

