### PR TITLE
Test and fix include depth bug

### DIFF
--- a/tests/unit/test_142_include_depth_limit.py
+++ b/tests/unit/test_142_include_depth_limit.py
@@ -1,0 +1,9 @@
+from tests.framework import UnifiedTestCase
+
+
+class TestIncludeDepthLimit(UnifiedTestCase):
+    def test_include_depth_limit(self):
+        result = self.run_test("142_include_depth_limit")
+        self.validate_execution_success(result)
+        self.validate_test_output(result)
+

--- a/tests/unit/test_142_include_depth_limit.yml
+++ b/tests/unit/test_142_include_depth_limit.yml
@@ -1,0 +1,72 @@
+test:
+  name: Include Depth Limit 2 – No deeper arrows
+  description: Ensure include_depth=2 limits traversal; deeper includes are not shown when no file-specific include_filter is set.
+  category: unit
+  id: '142'
+---
+source_files:
+  main.c: |
+    #include "a1.h"
+    int main(void) { return 0; }
+  a1.h: |
+    #ifndef A1_H
+    #define A1_H
+    #include "a2.h"
+    #endif
+  a2.h: |
+    #ifndef A2_H
+    #define A2_H
+    #include "a3.h"
+    #endif
+  a3.h: |
+    #ifndef A3_H
+    #define A3_H
+    #include "a4.h"
+    #endif
+  a4.h: |
+    #ifndef A4_H
+    #define A4_H
+    #endif
+---
+config.json: |
+  {
+    "project_name": "include_depth_limit",
+    "source_folders": ["."],
+    "output_dir": "./output",
+    "recursive_search": true,
+    "include_depth": 2,
+    "include_filter_local_only": false,
+    "always_show_includes": true,
+    "hide_macro_values": true,
+    "convert_empty_class_to_artifact": true,
+    "max_function_signature_chars": 120
+  }
+---
+assertions:
+  execution:
+    exit_code: 0
+    output_files: ["model.json", "model_transformed.json", "main.puml"]
+    max_execution_time: 30.0
+  model:
+    validate_structure: true
+    files:
+      main.c:
+        includes: ["a1.h"]
+    includes_exist: ["a1.h", "a2.h"]
+  puml:
+    syntax_valid: true
+    files:
+      main.puml:
+        contains_lines:
+          - "MAIN --> HEADER_A1 : <<include>>"
+          - "HEADER_A1 --> HEADER_A2 : <<include>>"
+        not_contains_lines:
+          - "HEADER_A2 --> HEADER_A3 : <<include>>"
+          - "HEADER_A3 --> HEADER_A4 : <<include>>"
+  files:
+    output_dir_exists: ./output
+    files_exist:
+      - ./output/model.json
+      - ./output/model_transformed.json
+      - ./output/main.puml
+


### PR DESCRIPTION
Add a unit test to verify `include_depth=2` correctly limits include relationships, confirming existing functionality.

A bug was reported where `include_depth=2` was not respected, showing deeper includes than expected. This PR introduces a dedicated unit test to reproduce this scenario with the specified configuration. The test passes, indicating that the `include_depth` logic in the transformer correctly limits include relationships to the specified depth, and no code changes were required to fix the reported issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-57f0f4e6-42e0-4034-a27e-d48578f03af4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57f0f4e6-42e0-4034-a27e-d48578f03af4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

