### PR TITLE
Update readme workflow status links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 A Python tool for converting C/C++ source code to PlantUML diagrams. Analyzes C/C++ projects and generates comprehensive PlantUML class diagrams showing structs, enums, unions, functions, global variables, macros, typedefs, and include relationships.
 
 ## Status
-[![Run Tests](https://github.com/fischerjooo/c2puml/actions/workflows/test.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/test.yml)
-[![Convert PlantUML to PNG](https://github.com/fischerjooo/c2puml/actions/workflows/puml2png.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/puml2png.yml)
-[![Coverage Reports](https://github.com/fischerjooo/c2puml/actions/workflows/test-coverage.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/test-coverage.yml)
-[![Deploy Website](https://github.com/fischerjooo/c2puml/actions/workflows/deploy-website.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/deploy-website.yml)
+[![00. Test](https://github.com/fischerjooo/c2puml/actions/workflows/00-test.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/00-test.yml)
+[![02. PlantUML to PNG](https://github.com/fischerjooo/c2puml/actions/workflows/02-puml-to-png.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/02-puml-to-png.yml)
+[![01. Test and Coverage](https://github.com/fischerjooo/c2puml/actions/workflows/01-test-and-coverage.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/01-test-and-coverage.yml)
+[![03. Deploy Website](https://github.com/fischerjooo/c2puml/actions/workflows/03-deploy-website.yml/badge.svg)](https://github.com/fischerjooo/c2puml/actions/workflows/03-deploy-website.yml)
 
 ## Reports
 


### PR DESCRIPTION
Update `README.md` status badges to reflect current GitHub workflow names and display labels.

---
<a href="https://cursor.com/background-agent?bcId=bc-011e9df4-b05a-4553-8e19-1cb7db2d37f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-011e9df4-b05a-4553-8e19-1cb7db2d37f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

