### PR TITLE
Update release workflow for version override

### DIFF
--- a/.github/workflows/10-release.yml
+++ b/.github/workflows/10-release.yml
@@ -3,8 +3,8 @@ name: 10. Release
 on:
   workflow_dispatch:
     inputs:
-      release_suffix:
-        description: 'Optional suffix to append to tag name (e.g., "beta", "rc1")'
+      version_override:
+        description: 'Optional version override (defaults to current date-based version)'
         required: false
         default: ''
         type: string
@@ -37,18 +37,25 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: "10.04 Generate release date and tag"
+      - name: "10.04 Generate release metadata and tag"
         id: release_date
         run: |
-          # Always use current date
+          # Always compute current date for notes
           RELEASE_DATE=$(date +%Y-%m-%d)
           echo "date=${RELEASE_DATE}" >> $GITHUB_OUTPUT
-          
-          # Build tag name with optional suffix
-          TAG_NAME="v${RELEASE_DATE}"
-          if [ -n "${{ github.event.inputs.release_suffix }}" ]; then
-            TAG_NAME="${TAG_NAME}-${{ github.event.inputs.release_suffix }}"
+
+          # Determine version: user-provided override or date-based default (YYYY.M.D)
+          if [ -n "${{ github.event.inputs.version_override }}" ]; then
+            VERSION="${{ github.event.inputs.version_override }}"
+            # Normalize: strip leading 'v' if provided
+            VERSION="${VERSION#v}"
+          else
+            VERSION=$(date +%Y.%-m.%-d)
           fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+          # Build tag name from version
+          TAG_NAME="v${VERSION}"
           echo "tag=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: "10.05 Update release branch"
@@ -94,8 +101,8 @@ jobs:
 
       - name: "10.07 Update version in pyproject.toml and __init__.py"
         run: |
-          # Generate version in format YYYY.M.D (e.g., 2025.8.2)
-          VERSION=$(date +%Y.%-m.%-d)
+          # Use version determined earlier (override or date-based)
+          VERSION="${{ steps.release_date.outputs.version }}"
           echo "📝 Updating version to: $VERSION"
           
           # Update the version in pyproject.toml


### PR DESCRIPTION
Replace `release_suffix` with `version_override` in the release workflow to allow manual version specification.

This change introduces an optional `version_override` input, allowing users to explicitly set the release version and tag. If no override is provided, the workflow defaults to a date-based version (YYYY.M.D). This provides greater flexibility for release numbering compared to only appending a suffix.

---
<a href="https://cursor.com/background-agent?bcId=bc-aaf3c314-4e43-4f11-b450-cc8e8731180c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aaf3c314-4e43-4f11-b450-cc8e8731180c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

